### PR TITLE
feat: NRQL result improvements, logs support, autocomplete & editor migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build artifacts
+nrgrafanaplugin-newrelic-datasource/
+
 # Logs
 logs
 *.log

--- a/__mocks__/monaco-editor.js
+++ b/__mocks__/monaco-editor.js
@@ -1,7 +1,0 @@
-module.exports = {
-      editor: {
-        getModelMarkers: jest.fn().mockReturnValue([]),
-        // Add other mocked methods as needed
-      },
-      Position: {}, // Mock other modules if required
-    };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,6 @@
 process.env.TZ = 'UTC';
 
 module.exports = {
-  moduleNameMapper: {
-    // Mock monaco-editor to avoid issues with Jest and Monaco Editor
-    'monaco-editor': '<rootDir>/node_modules/monaco-editor/esm/vs/editor/editor.api.d.ts',
-  },
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@grafana/runtime": "^12.0.1",
         "@grafana/schema": "^12.0.1",
         "@grafana/ui": "^12.0.1",
-        "@monaco-editor/react": "^4.7.0",
         "big-integer": "^1.6.52",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -2164,20 +2163,6 @@
       "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
-      }
-    },
-    "node_modules/@monaco-editor/react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
-      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@monaco-editor/loader": "^1.5.0"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newrelic-grafana-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "newrelic-grafana-plugin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@grafana/runtime": "^12.0.1",
     "@grafana/schema": "^12.0.1",
     "@grafana/ui": "^12.0.1",
-    "@monaco-editor/react": "^4.7.0",
     "big-integer": "^1.6.52",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-grafana-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A comprehensive Grafana data source plugin for New Relic with full NRQL support",
   "keywords": [
     "grafana",

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -28,17 +28,16 @@ func IsCountQuery(results *nrdb.NRDBResultContainer) bool {
 func FormatQueryResults(results *nrdb.NRDBResultContainer, query backend.DataQuery) *backend.DataResponse {
 	resp := &backend.DataResponse{}
 
-	// Print results as JSON for debugging
-	resultsJSON, _ := json.MarshalIndent(results, "", "  ")
-	log.DefaultLogger.Debug("Result count: %d\nResults:\n%s",
-		len(results.Results), string(resultsJSON))
+	log.DefaultLogger.Debug("Result count", "count", len(results.Results))
 
 	if len(results.Results) == 0 {
 		return resp
 	}
 
 	// Route to appropriate formatter based on query type
-	if isSimpleCountQuery(results) {
+	if isCompareWithQuery(results) {
+		return formatCompareWithQuery(results, query)
+	} else if isSimpleCountQuery(results) {
 		return formatSimpleCountQuery(results, query)
 	} else if isFacetedCountQuery(results) {
 		return formatFacetedCountQuery(results, query)
@@ -50,11 +49,112 @@ func FormatQueryResults(results *nrdb.NRDBResultContainer, query backend.DataQue
 	}
 }
 
-// isSimpleCountQuery checks if the results represent a simple count query
+// isCompareWithQuery checks if the results contain COMPARE WITH data.
+// NR returns a "comparison" field with values "current" and "previous".
+func isCompareWithQuery(results *nrdb.NRDBResultContainer) bool {
+	if len(results.Results) < 2 {
+		return false
+	}
+	_, hasComparison := results.Results[0]["comparison"]
+	return hasComparison
+}
+
+// formatCompareWithQuery formats COMPARE WITH results into separate current/previous frames.
+// Current values are displayed as primary metrics; previous values get a "previous" label.
+func formatCompareWithQuery(results *nrdb.NRDBResultContainer, query backend.DataQuery) *backend.DataResponse {
+	resp := &backend.DataResponse{}
+
+	// Separate current and previous results
+	var currentResults, previousResults []nrdb.NRDBResult
+	for _, result := range results.Results {
+		if comp, ok := result["comparison"].(string); ok {
+			switch comp {
+			case "current":
+				currentResults = append(currentResults, result)
+			case "previous":
+				previousResults = append(previousResults, result)
+			}
+		}
+	}
+
+	log.DefaultLogger.Debug("COMPARE WITH query detected",
+		"currentCount", len(currentResults),
+		"previousCount", len(previousResults))
+
+	// Collect metric field names from current results (exclude system fields)
+	excludeFields := map[string]bool{
+		"comparison": true, "timestamp": true, "inspectedCount": true,
+		"beginTimeSeconds": true, "endTimeSeconds": true,
+	}
+
+	var metricFields []string
+	if len(currentResults) > 0 {
+		for key := range currentResults[0] {
+			if !excludeFields[key] {
+				metricFields = append(metricFields, key)
+			}
+		}
+	}
+
+	now := time.Now()
+
+	// Create frame for current values (primary display)
+	currentFrame := data.NewFrame("current")
+	currentFrame.Fields = append(currentFrame.Fields,
+		data.NewField("time", nil, []time.Time{now}))
+
+	for _, fieldName := range metricFields {
+		if len(currentResults) > 0 {
+			if val, ok := currentResults[0][fieldName].(float64); ok {
+				currentFrame.Fields = append(currentFrame.Fields,
+					data.NewField(fieldName, nil, []float64{val}))
+			}
+		}
+	}
+	resp.Frames = append(resp.Frames, currentFrame)
+
+	// Create frame for previous values with comparison label
+	if len(previousResults) > 0 {
+		previousFrame := data.NewFrame("previous")
+		previousFrame.Fields = append(previousFrame.Fields,
+			data.NewField("time", nil, []time.Time{now.Add(-time.Hour)}))
+
+		for _, fieldName := range metricFields {
+			if val, ok := previousResults[0][fieldName].(float64); ok {
+				labels := map[string]string{"comparison": "previous"}
+				previousFrame.Fields = append(previousFrame.Fields,
+					data.NewField(fieldName, labels, []float64{val}))
+			}
+		}
+		resp.Frames = append(resp.Frames, previousFrame)
+	}
+
+	return resp
+}
+
+// isSimpleCountQuery checks if the results represent a simple count query.
+// It verifies that "count" is the ONLY meaningful metric field in the result.
+// This prevents misdetecting apdex queries (which also have "count" alongside
+// "score", "s", "t", "f", and "apdex.duration") as simple count queries.
 func isSimpleCountQuery(results *nrdb.NRDBResultContainer) bool {
-	return len(results.Results) == 1 &&
-		results.Results[0][utils.CountFieldName] != nil &&
-		results.Results[0][utils.FacetFieldName] == nil
+	if len(results.Results) != 1 ||
+		results.Results[0][utils.CountFieldName] == nil ||
+		results.Results[0][utils.FacetFieldName] != nil {
+		return false
+	}
+
+	// Verify count is the ONLY metric field (exclude internal fields)
+	internalFields := map[string]bool{
+		"count": true, "inspectedCount": true,
+		"beginTimeSeconds": true, "endTimeSeconds": true,
+		"timestamp": true,
+	}
+	for key := range results.Results[0] {
+		if !internalFields[key] {
+			return false // Has additional fields (apdex score, s, t, f, etc.)
+		}
+	}
+	return true
 }
 
 // isFacetedCountQuery checks if the results represent a faceted count query
@@ -146,14 +246,16 @@ func hasTimeseriesDataMulti(results *nrdb.NRDBResultContainerMultiResultCustomiz
 	return false
 }
 
-// formatSimpleCountQuery formats results from a simple count query
+// formatSimpleCountQuery formats results from a simple count query.
+// Returns a single frame with the count value. Grafana stat/table panels
+// display this directly. For time series panels, users should use TIMESERIES.
 func formatSimpleCountQuery(results *nrdb.NRDBResultContainer, query backend.DataQuery) *backend.DataResponse {
 	resp := &backend.DataResponse{}
 
 	// Extract count value
 	count := extractCountValue(results.Results[0])
 
-	// Frame 1: For table/stat panels - just the count with no time
+	// Single frame with count value - works in stat, table, and gauge panels
 	valueFrame := data.NewFrame("count",
 		data.NewField("count", nil, []float64{count}),
 	)
@@ -161,11 +263,7 @@ func formatSimpleCountQuery(results *nrdb.NRDBResultContainer, query backend.Dat
 		PreferredVisualization: data.VisTypeTable,
 	}
 
-	// Frame 2: For time series/graph panels - count with time points
-	graphFrame := createCountTimeSeriesFrame(count, query)
-
-	// Add both frames to the response
-	resp.Frames = append(resp.Frames, valueFrame, graphFrame)
+	resp.Frames = append(resp.Frames, valueFrame)
 	return resp
 }
 
@@ -215,19 +313,15 @@ func formatFacetedCountQuery(results *nrdb.NRDBResultContainer, query backend.Da
 
 	// Get facet names
 	facetNames := extractFacetNames(results)
-	log.DefaultLogger.Debug("Facet names extracted: %v", facetNames)
+	log.DefaultLogger.Debug("Facet names extracted", "facetNames", facetNames)
 
 	// Extract data
 	counts, facetFields := extractFacetedData(results, facetNames)
-	log.DefaultLogger.Debug("Counts: %v, Facet fields: %v", counts, facetFields)
+	log.DefaultLogger.Debug("Extracted faceted data", "counts", counts, "facetFields", facetFields)
 
-	// Create separate frames for each facet value (like Grafana Cloud plugin)
+	// Create separate frames for each result with ALL facet dimensions as labels
 	if len(facetNames) > 0 {
-		facetName := facetNames[0] // Use the first facet for labels
-		facetValues := facetFields[facetName]
-
-		for i, facetValue := range facetValues {
-			// Create a frame for each facet value
+		for i := range results.Results {
 			frame := data.NewFrame("")
 
 			// Add time field
@@ -235,17 +329,22 @@ func formatFacetedCountQuery(results *nrdb.NRDBResultContainer, query backend.Da
 			frame.Fields = append(frame.Fields,
 				data.NewField("time", nil, []time.Time{now}))
 
-			// Add count field with facet label (matching Grafana Cloud plugin)
-			countField := data.NewField("count", map[string]string{
-				facetName: facetValue,
-			}, []float64{counts[i]})
+			// Build labels from ALL facet dimensions (not just the first one)
+			labels := make(map[string]string)
+			for _, facetName := range facetNames {
+				if values, ok := facetFields[facetName]; ok && i < len(values) {
+					labels[facetName] = values[i]
+				}
+			}
+
+			countField := data.NewField("count", labels, []float64{counts[i]})
 			frame.Fields = append(frame.Fields, countField)
 
 			resp.Frames = append(resp.Frames, frame)
 		}
 	}
 
-	log.DefaultLogger.Debug("Total frames in response: %d", len(resp.Frames))
+	log.DefaultLogger.Debug("Total frames in response", "frameCount", len(resp.Frames))
 
 	return resp
 }
@@ -260,7 +359,7 @@ func createPieChartFrame(facetNames []string, counts []float64, facetFields map[
 		facetName := facetNames[0] // Use the first facet for pie chart labels
 		labels := facetFields[facetName]
 
-		log.DefaultLogger.Debug("Creating pie chart frame: facet=%s, labels=%v, counts=%v", facetName, labels, counts)
+		log.DefaultLogger.Debug("Creating pie chart frame", "facet", facetName, "labels", labels, "counts", counts)
 
 		// Create fields for pie chart - labels first, then values
 		pieFrame.Fields = append(pieFrame.Fields,
@@ -302,6 +401,47 @@ func extractFacetNamesMulti(results *nrdb.NRDBResultContainerMultiResultCustomiz
 		return metadata.Facets
 	}
 	return nil
+}
+
+// extractAliasesFromMetadataMulti extracts metric field names from results for Multi type
+// Since the flattened response doesn't preserve alias metadata, we extract field names from actual results
+// Returns an array of metric field names like ["Errors", "Success", "Error %"] or ["count", "sum.duration", etc.]
+func extractAliasesFromMetadataMulti(results *nrdb.NRDBResultContainerMultiResultCustomized) []string {
+	var fieldNames []string
+	seenFields := make(map[string]bool)
+
+	// Build a set of facet names to exclude facet value fields (e.g., "host", "appName")
+	// These are duplicates of the "facet" field and should not be treated as metrics
+	facetNameSet := make(map[string]bool)
+	for _, fn := range extractFacetNamesMulti(results) {
+		facetNameSet[fn] = true
+	}
+
+	// Get the results to process
+	resultsToProcess := results.Results
+	if len(resultsToProcess) == 0 {
+		resultsToProcess = results.OtherResult
+	}
+
+	// Extract unique field names from the first few results
+	// (they should all have the same structure)
+	for i, result := range resultsToProcess {
+		if i >= 5 { // Only check first 5 results for efficiency
+			break
+		}
+
+		for key := range result {
+			// Skip non-metric fields AND facet value fields (e.g., "host", "request.uri")
+			if key != "timestamp" && key != "beginTimeSeconds" && key != "endTimeSeconds" &&
+			   key != "facet" && key != "inspectedCount" && !seenFields[key] && !facetNameSet[key] {
+				fieldNames = append(fieldNames, key)
+				seenFields[key] = true
+			}
+		}
+	}
+
+	log.DefaultLogger.Debug("Extracted metric field names from results (Multi)", "fieldNames", fieldNames, "count", len(fieldNames))
+	return fieldNames
 }
 
 // extractFacetedData extracts counts and facet values from results
@@ -422,9 +562,11 @@ func formatStandardQuery(results *nrdb.NRDBResultContainer, query backend.DataQu
 	// Extract field names
 	fieldNames := extractFieldNames(results)
 
-	// Add time field
+	// Add time field with bucket interval
 	times := createTimeField(results, query)
-	frame.Fields = append(frame.Fields, data.NewField(utils.TimeFieldName, nil, times))
+	timeField := data.NewField(utils.TimeFieldName, nil, times)
+	setTimeFieldInterval(timeField, calculateBucketIntervalMs(results.Results))
+	frame.Fields = append(frame.Fields, timeField)
 
 	// Add data fields
 	addDataFields(frame, results, fieldNames)
@@ -442,11 +584,9 @@ func formatFacetedAggregationQuery(results *nrdb.NRDBResultContainer, query back
 		return resp
 	}
 
-	facetName := facetNames[0] // Use the first facet for grouping
-
-	// Group results by facet value
-	facetData := groupResultsByFacet(results, facetName)
-	log.DefaultLogger.Debug("Faceted aggregation - Grouped into %d facet groups", len(facetData))
+	// Group results by ALL facet values (not just the first one)
+	facetData := groupResultsByAllFacets(results, facetNames)
+	log.DefaultLogger.Debug("Faceted aggregation - Grouped facet groups", "groupCount", len(facetData))
 
 	// Get all field names and filter to only include aggregation fields
 	allFieldNames := extractFieldNames(results)
@@ -459,32 +599,34 @@ func formatFacetedAggregationQuery(results *nrdb.NRDBResultContainer, query back
 		}
 	}
 
-	log.DefaultLogger.Debug("Faceted aggregation - Aggregation fields: %v", aggregationFields)
+	log.DefaultLogger.Debug("Faceted aggregation - Aggregation fields", "fields", aggregationFields)
 
-	// Create separate frames for each facet value
-	for facetValue, facetResults := range facetData {
-		// Use facet value directly in the frame name
-		log.DefaultLogger.Debug("Creating frame with facet value: %s", facetValue)
-		frame := data.NewFrame(facetValue)
-		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetResults}, query)
-		frame.Fields = append(frame.Fields, data.NewField("time", nil, times))
+	// Create separate frames for each facet combination
+	for facetKey, facetInfo := range facetData {
+		// Use facet key as the frame name
+		log.DefaultLogger.Debug("Creating frame with facet key", "facetKey", facetKey)
+		frame := data.NewFrame(facetKey)
+		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetInfo.Results}, query)
+		timeField := data.NewField("time", nil, times)
+		setTimeFieldInterval(timeField, calculateBucketIntervalMs(facetInfo.Results))
+		frame.Fields = append(frame.Fields, timeField)
 
 		// Add aggregation fields with facet labels
 		for _, fieldName := range aggregationFields {
 			// Handle different aggregation field types
 			if strings.HasPrefix(fieldName, "percentile.") {
 				// Handle percentile objects - extract individual percentile values
-				addPercentileFields(frame, facetResults, fieldName, facetName, facetValue)
+				addPercentileFieldsWithLabels(frame, facetInfo.Results, fieldName, facetInfo.Labels)
 			} else {
 				// Handle regular aggregation fields (sum.duration, average.duration, etc.)
-				addRegularAggregationField(frame, facetResults, fieldName, facetName, facetValue)
+				addRegularAggregationFieldWithLabels(frame, facetInfo.Results, fieldName, facetInfo.Labels)
 			}
 		}
 
 		resp.Frames = append(resp.Frames, frame)
 	}
 
-	log.DefaultLogger.Debug("Faceted aggregation - Total frames in response: %d", len(resp.Frames))
+	log.DefaultLogger.Debug("Faceted aggregation - Total frames in response", "frameCount", len(resp.Frames))
 	return resp
 }
 
@@ -564,6 +706,75 @@ func addRegularAggregationField(frame *data.Frame, facetResults []nrdb.NRDBResul
 	frame.Fields = append(frame.Fields, field)
 }
 
+// addPercentileFieldsWithLabels handles percentile objects with multiple facet labels
+func addPercentileFieldsWithLabels(frame *data.Frame, facetResults []nrdb.NRDBResult, fieldName string, labels map[string]string) {
+	// First pass: collect all percentile keys across all results
+	percentileKeys := make(map[string]bool)
+	for _, result := range facetResults {
+		if result[fieldName] != nil {
+			if objVal, ok := result[fieldName].(map[string]interface{}); ok {
+				for key := range objVal {
+					percentileKeys[key] = true
+				}
+			}
+		}
+	}
+
+	// Create a field for each percentile (e.g., percentile.duration.95)
+	for percentileKey := range percentileKeys {
+		fieldNameWithPercentile := fmt.Sprintf("%s.%s", fieldName, percentileKey)
+
+		// Extract values for this specific percentile
+		values := make([]*float64, len(facetResults))
+		for i, result := range facetResults {
+			if result[fieldName] != nil {
+				if objVal, ok := result[fieldName].(map[string]interface{}); ok {
+					if percentileVal, exists := objVal[percentileKey]; exists {
+						if floatVal, ok := percentileVal.(float64); ok {
+							values[i] = &floatVal
+						} else if strVal, ok := percentileVal.(string); ok {
+							if parsed, err := parseNumericString(strVal); err == nil {
+								values[i] = &parsed
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Create field with all facet labels
+		field := data.NewField(fieldNameWithPercentile, labels, values)
+		frame.Fields = append(frame.Fields, field)
+	}
+}
+
+// addRegularAggregationFieldWithLabels handles regular aggregation fields with multiple facet labels
+func addRegularAggregationFieldWithLabels(frame *data.Frame, facetResults []nrdb.NRDBResult, fieldName string, labels map[string]string) {
+	// Extract values for this field
+	values := make([]*float64, len(facetResults))
+	for i, result := range facetResults {
+		if result[fieldName] != nil && result[fieldName] != "" {
+			if val, ok := result[fieldName].(float64); ok {
+				values[i] = &val
+			} else if strVal, ok := result[fieldName].(string); ok && strVal != "" {
+				if parsed, err := parseNumericString(strVal); err == nil {
+					values[i] = &parsed
+				}
+			} else if intVal, ok := result[fieldName].(int); ok {
+				floatVal := float64(intVal)
+				values[i] = &floatVal
+			} else if int64Val, ok := result[fieldName].(int64); ok {
+				floatVal := float64(int64Val)
+				values[i] = &floatVal
+			}
+		}
+	}
+
+	// Create field with all facet labels
+	field := data.NewField(fieldName, labels, values)
+	frame.Fields = append(frame.Fields, field)
+}
+
 // isFacetFieldName checks if a field name corresponds to a facet field name
 func isFacetFieldName(fieldName string, facetNames []string) bool {
 	for _, facetName := range facetNames {
@@ -574,7 +785,93 @@ func isFacetFieldName(fieldName string, facetNames []string) bool {
 	return false
 }
 
-// groupResultsByFacet groups results by facet value for aggregation queries
+// FacetGroupInfo holds results and labels for a facet group
+type FacetGroupInfo struct {
+	Results []nrdb.NRDBResult
+	Labels  map[string]string
+}
+
+// groupResultsByAllFacets groups results by ALL facet values (multi-dimensional)
+func groupResultsByAllFacets(results *nrdb.NRDBResultContainer, facetNames []string) map[string]*FacetGroupInfo {
+	grouped := make(map[string]*FacetGroupInfo)
+
+	for _, result := range results.Results {
+		// Extract all facet values
+		facetValues := extractAllFacetValues(result, facetNames)
+
+		if len(facetValues) == 0 {
+			continue
+		}
+
+		// Create a composite key from all facet values
+		facetKey := createCompositeFacetKey(facetValues, facetNames)
+
+		// Create labels map
+		labels := make(map[string]string)
+		for i, facetName := range facetNames {
+			if i < len(facetValues) {
+				labels[facetName] = facetValues[i]
+			}
+		}
+
+		// Group by composite key
+		if _, exists := grouped[facetKey]; !exists {
+			grouped[facetKey] = &FacetGroupInfo{
+				Results: []nrdb.NRDBResult{},
+				Labels:  labels,
+			}
+		}
+		grouped[facetKey].Results = append(grouped[facetKey].Results, result)
+	}
+
+	return grouped
+}
+
+// extractAllFacetValues extracts all facet values from a result
+func extractAllFacetValues(result map[string]interface{}, facetNames []string) []string {
+	var values []string
+
+	facetData, hasFacet := result[utils.FacetFieldName]
+	if !hasFacet {
+		return values
+	}
+
+	// Handle facet as array (multiple facets)
+	if facetArray, ok := facetData.([]interface{}); ok {
+		for _, value := range facetArray {
+			values = append(values, fmt.Sprintf("%v", value))
+		}
+	} else {
+		// Handle single facet value
+		values = append(values, fmt.Sprintf("%v", facetData))
+	}
+
+	return values
+}
+
+// createCompositeFacetKey creates a unique key from multiple facet values
+func createCompositeFacetKey(facetValues []string, facetNames []string) string {
+	if len(facetValues) == 0 {
+		return ""
+	}
+
+	// For single facet, return just the value
+	if len(facetValues) == 1 {
+		return facetValues[0]
+	}
+
+	// For multiple facets, create a descriptive key
+	var parts []string
+	for i, value := range facetValues {
+		if i < len(facetNames) {
+			// Use facet name for clarity: "Server Error, grafana-traffic-generator, host1"
+			parts = append(parts, value)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// groupResultsByFacet groups results by facet value for aggregation queries (legacy - single facet)
 func groupResultsByFacet(results *nrdb.NRDBResultContainer, facetName string) map[string][]nrdb.NRDBResult {
 	grouped := make(map[string][]nrdb.NRDBResult)
 
@@ -603,15 +900,31 @@ func hasCountField(results *nrdb.NRDBResultContainer) bool {
 	return hasCount
 }
 
-// extractFieldNames extracts unique field names from results
+// extractFieldNames extracts unique field names from results.
+// When an apdex.* object field is present, it filters out the duplicate top-level
+// fields (count, f, s, score, t) that NR returns redundantly alongside the nested object.
 func extractFieldNames(results *nrdb.NRDBResultContainer) []string {
 	fieldNamesMap := make(map[string]struct{})
+	hasApdexObject := false
+
 	for _, result := range results.Results {
 		for key := range result {
 			// Exclude timestamp fields and New Relic TIMESERIES fields from data fields
 			if key != utils.TimestampFieldName && key != "beginTimeSeconds" && key != "endTimeSeconds" {
 				fieldNamesMap[key] = struct{}{}
 			}
+			if strings.HasPrefix(key, "apdex.") {
+				hasApdexObject = true
+			}
+		}
+	}
+
+	// When apdex object is present, NR duplicates its sub-fields at top level.
+	// Remove the duplicates to avoid showing each value twice.
+	if hasApdexObject {
+		apdexDuplicates := []string{"count", "f", "s", "score", "t"}
+		for _, dup := range apdexDuplicates {
+			delete(fieldNamesMap, dup)
 		}
 	}
 
@@ -641,6 +954,30 @@ func createTimeField(results *nrdb.NRDBResultContainer, query backend.DataQuery)
 		}
 	}
 	return times
+}
+
+// calculateBucketIntervalMs calculates the timeseries bucket interval in milliseconds
+// from the first result that has both beginTimeSeconds and endTimeSeconds.
+// Returns 0 if no interval can be determined.
+func calculateBucketIntervalMs(results []nrdb.NRDBResult) float64 {
+	for _, result := range results {
+		beginTs, hasBegin := result["beginTimeSeconds"].(float64)
+		endTs, hasEnd := result["endTimeSeconds"].(float64)
+		if hasBegin && hasEnd && endTs > beginTs {
+			return (endTs - beginTs) * 1000 // Convert seconds to milliseconds
+		}
+	}
+	return 0
+}
+
+// setTimeFieldInterval sets the bucket interval on a time field's config if interval > 0
+func setTimeFieldInterval(timeField *data.Field, intervalMs float64) {
+	if intervalMs > 0 {
+		if timeField.Config == nil {
+			timeField.Config = &data.FieldConfig{}
+		}
+		timeField.Config.Interval = intervalMs
+	}
 }
 
 // parseNumericString attempts to parse a string as a float64, handling scientific notation
@@ -702,17 +1039,16 @@ func addDataFields(frame *data.Frame, results *nrdb.NRDBResultContainer, fieldNa
 				frame.Fields = append(frame.Fields, data.NewField(fieldName, nil, values))
 
 			case "array":
-				// Handle arrays (like histogram, uniques) - convert to JSON string for display
+				// Handle arrays (like histogram, uniques) - convert to comma-separated string
 				values := make([]string, len(results.Results))
 				for i, result := range results.Results {
 					if result[fieldName] != nil {
 						if arrayVal, ok := result[fieldName].([]interface{}); ok {
-							// Convert array to JSON string for better display
-							if jsonBytes, err := json.Marshal(arrayVal); err == nil {
-								values[i] = string(jsonBytes)
-							} else {
-								values[i] = fmt.Sprintf("%v", arrayVal)
+							parts := make([]string, len(arrayVal))
+							for j, elem := range arrayVal {
+								parts[j] = fmt.Sprintf("%v", elem)
 							}
+							values[i] = strings.Join(parts, ", ")
 						} else {
 							values[i] = fmt.Sprintf("%v", result[fieldName])
 						}
@@ -721,10 +1057,12 @@ func addDataFields(frame *data.Frame, results *nrdb.NRDBResultContainer, fieldNa
 				frame.Fields = append(frame.Fields, data.NewField(fieldName, nil, values))
 
 			case "object":
-				// Handle objects (like percentile results) - convert to JSON string or extract values
-				if strings.HasPrefix(fieldName, "percentile.") {
-					// Special handling for percentile objects - try to extract individual percentile values
-					handlePercentileField(frame, results, fieldName)
+				// Handle nested objects - flatten into individual fields for numeric sub-values
+				if strings.HasPrefix(fieldName, "percentile.") || strings.HasPrefix(fieldName, "apdex.") {
+					// Flatten percentile and apdex objects into individual fields
+					// e.g., percentile.duration → percentile.duration.50, percentile.duration.90
+					// e.g., apdex.duration → apdex.duration.score, apdex.duration.s, apdex.duration.t
+					handleNestedObjectField(frame, results, fieldName)
 				} else {
 					// General object handling - convert to JSON string
 					values := make([]string, len(results.Results))
@@ -770,9 +1108,12 @@ func addDataFields(frame *data.Frame, results *nrdb.NRDBResultContainer, fieldNa
 	}
 }
 
-// handlePercentileField handles percentile objects by creating separate fields for each percentile
-func handlePercentileField(frame *data.Frame, results *nrdb.NRDBResultContainer, fieldName string) {
-	// Collect all percentile keys from all results
+// handleNestedObjectField handles nested object fields (percentile, apdex, etc.)
+// by creating separate numeric fields for each sub-key.
+// e.g., "percentile.duration" with {"50": 0.01, "90": 0.08} → "percentile.duration.50", "percentile.duration.90"
+// e.g., "apdex.duration" with {"score": 0.99, "s": 530908} → "apdex.duration.score", "apdex.duration.s"
+func handleNestedObjectField(frame *data.Frame, results *nrdb.NRDBResultContainer, fieldName string) {
+	// Collect all sub-keys from all results
 	percentileKeys := make(map[string]bool)
 	for _, result := range results.Results {
 		if result[fieldName] != nil {
@@ -813,7 +1154,7 @@ func handlePercentileField(frame *data.Frame, results *nrdb.NRDBResultContainer,
 func formatFacetedTimeseriesQuery(results *nrdb.NRDBResultContainer, query backend.DataQuery) *backend.DataResponse {
 	// Get facet names
 	facetNames := extractFacetNames(results)
-	log.DefaultLogger.Debug("Faceted timeseries - Facet names extracted: %v", facetNames)
+	log.DefaultLogger.Debug("Faceted timeseries - Facet names extracted", "facetNames", facetNames)
 
 	if len(facetNames) == 0 {
 		// No facets, fall back to standard query
@@ -830,49 +1171,83 @@ func formatFacetedTimeseriesQueryMulti(results *nrdb.NRDBResultContainerMultiRes
 	resp := &backend.DataResponse{}
 
 	facetNames := extractFacetNamesMulti(results)
-	log.DefaultLogger.Debug("Faceted timeseries - Facet names extracted: %v", facetNames)
+	log.DefaultLogger.Debug("Faceted timeseries - Facet names extracted", "facetNames", facetNames)
 
 	if len(facetNames) == 0 {
 		return formatStandardQueryMulti(results, query)
 	}
 
-	facetData := groupTimeseriesByFacetMulti(results, facetNames[0])
-	log.DefaultLogger.Debug("Faceted timeseries - Grouped into %d facet groups", len(facetData))
+	// Use ALL facets, not just the first one
+	facetData := groupTimeseriesByAllFacetsMulti(results, facetNames)
+	log.DefaultLogger.Debug("Faceted timeseries - Grouped facet groups", "groupCount", len(facetData))
 
 	// Debug facet data
 	keys := make([]string, 0, len(facetData))
 	for k := range facetData {
 		keys = append(keys, k)
 	}
-	log.DefaultLogger.Debug("Facet data keys: %v", keys)
+	log.DefaultLogger.Debug("Facet data keys", "keys", keys)
 
-	for facetValue, facetResults := range facetData {
-		// Use just the facet value as the frame name to match test expectations
-		log.DefaultLogger.Debug("Creating frame with name: %s", facetValue)
-		frame := data.NewFrame(facetValue)
-		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetResults}, query)
-		frame.Fields = append(frame.Fields, data.NewField("time", nil, times))
+	// Extract aliases from metadata for proper metric naming
+	aliases := extractAliasesFromMetadataMulti(results)
+	log.DefaultLogger.Debug("Extracted aliases from metadata", "aliases", aliases, "count", len(aliases))
 
-		counts := make([]float64, len(facetResults))
-		for i, result := range facetResults {
-			if countValue, ok := result[utils.CountFieldName].(float64); ok {
-				counts[i] = countValue
+	for facetKey, facetInfo := range facetData {
+		// Use composite facet key as frame name
+		log.DefaultLogger.Debug("Creating frame with name", "name", facetKey)
+		frame := data.NewFrame(facetKey)
+		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetInfo.Results}, query)
+		timeField := data.NewField("time", nil, times)
+		setTimeFieldInterval(timeField, calculateBucketIntervalMs(facetInfo.Results))
+		frame.Fields = append(frame.Fields, timeField)
+
+		// Extract ALL metric fields from the results, not just "count"
+		// Use the aliases we extracted (which are the actual field names from results)
+		// This preserves the order and names as they appear in the query
+		metricFieldNames := aliases
+		if len(metricFieldNames) == 0 {
+			// Fallback: collect unique metric names from results
+			metricNamesSet := make(map[string]bool)
+			for _, result := range facetInfo.Results {
+				for key := range result {
+					// Skip non-metric fields
+					if key != "timestamp" && key != "beginTimeSeconds" && key != "endTimeSeconds" &&
+					   key != "facet" && key != "inspectedCount" {
+						metricNamesSet[key] = true
+					}
+				}
+			}
+			// Convert to slice
+			for name := range metricNamesSet {
+				metricFieldNames = append(metricFieldNames, name)
 			}
 		}
 
-		countField := data.NewField("count", map[string]string{
-			facetNames[0]: facetValue,
-		}, counts)
-		frame.Fields = append(frame.Fields, countField)
+		log.DefaultLogger.Debug("Processing metrics for facet", "facetKey", facetKey, "metricCount", len(metricFieldNames), "metrics", metricFieldNames)
+
+		// Create a field for each metric
+		for _, metricName := range metricFieldNames {
+			values := make([]*float64, len(facetInfo.Results))
+
+			for i, result := range facetInfo.Results {
+				if val, ok := result[metricName].(float64); ok {
+					values[i] = &val
+				}
+			}
+
+			// Use all facet labels, not just the first one
+			field := data.NewField(metricName, facetInfo.Labels, values)
+			frame.Fields = append(frame.Fields, field)
+		}
 
 		resp.Frames = append(resp.Frames, frame)
 	}
 
-	log.DefaultLogger.Debug("Faceted timeseries - Total frames in response: %d", len(resp.Frames))
+	log.DefaultLogger.Debug("Faceted timeseries - Total frames in response", "frameCount", len(resp.Frames))
 
 	// Log frame names for debugging
 	for i, frame := range resp.Frames {
-		log.DefaultLogger.Debug("Frame %d name: %s", i, frame.Name)
+		log.DefaultLogger.Debug("Frame name", "index", i, "name", frame.Name)
 	}
 
 	return resp
@@ -898,7 +1273,52 @@ func groupTimeseriesByFacet(results *nrdb.NRDBResultContainer, facetName string)
 	return grouped
 }
 
-// Multi version for NRDBResultContainerMultiResultCustomized
+// groupTimeseriesByAllFacetsMulti groups timeseries results by ALL facet values for Multi type
+func groupTimeseriesByAllFacetsMulti(results *nrdb.NRDBResultContainerMultiResultCustomized, facetNames []string) map[string]*FacetGroupInfo {
+	grouped := make(map[string]*FacetGroupInfo)
+
+	// Process data from OtherResult first, as it's the preferred location for faceted timeseries
+	resultsToProcess := results.OtherResult
+	if len(resultsToProcess) == 0 {
+		// Fallback to Results if OtherResult is empty
+		resultsToProcess = results.Results
+	}
+
+	for _, result := range resultsToProcess {
+		// Extract all facet values
+		facetValues := extractAllFacetValues(result, facetNames)
+
+		if len(facetValues) == 0 {
+			continue
+		}
+
+		// Create a composite key from all facet values
+		facetKey := createCompositeFacetKey(facetValues, facetNames)
+
+		// Create labels map
+		labels := make(map[string]string)
+		for i, facetName := range facetNames {
+			if i < len(facetValues) {
+				labels[facetName] = facetValues[i]
+			}
+		}
+
+		log.DefaultLogger.Debug("Grouping by composite facet", "facetKey", facetKey, "labels", labels)
+
+		// Group by composite key
+		if _, exists := grouped[facetKey]; !exists {
+			grouped[facetKey] = &FacetGroupInfo{
+				Results: []nrdb.NRDBResult{},
+				Labels:  labels,
+			}
+		}
+		grouped[facetKey].Results = append(grouped[facetKey].Results, result)
+	}
+
+	return grouped
+}
+
+// Multi version for NRDBResultContainerMultiResultCustomized (legacy - single facet)
 func groupTimeseriesByFacetMulti(results *nrdb.NRDBResultContainerMultiResultCustomized, facetName string) map[string][]nrdb.NRDBResult {
 	grouped := make(map[string][]nrdb.NRDBResult)
 
@@ -914,13 +1334,13 @@ func groupTimeseriesByFacetMulti(results *nrdb.NRDBResultContainerMultiResultCus
 		if facetArray, ok := result[utils.FacetFieldName].([]interface{}); ok && len(facetArray) > 0 {
 			// Clean up the format for array facets, extracting just the first value
 			facetValue = fmt.Sprintf("%v", facetArray[0])
-			log.DefaultLogger.Debug("Found facet array, extracted value: %v", facetValue)
+			log.DefaultLogger.Debug("Found facet array, extracted value", "value", facetValue)
 		} else if result[utils.FacetFieldName] != nil {
 			facetValue = fmt.Sprintf("%v", result[utils.FacetFieldName])
-			log.DefaultLogger.Debug("Found direct facet value: %v", facetValue)
+			log.DefaultLogger.Debug("Found direct facet value", "value", facetValue)
 		}
 		if facetValue != "" {
-			log.DefaultLogger.Debug("Using facet value '%s' for grouping", facetValue)
+			log.DefaultLogger.Debug("Using facet value for grouping", "facetValue", facetValue)
 			grouped[facetValue] = append(grouped[facetValue], result)
 		}
 	}
@@ -930,9 +1350,8 @@ func groupTimeseriesByFacetMulti(results *nrdb.NRDBResultContainerMultiResultCus
 // FormatFacetedTimeseriesResults returns a Grafana DataResponse for faceted timeseries queries
 func FormatFacetedTimeseriesResults(results *nrdb.NRDBResultContainerMultiResultCustomized, query backend.DataQuery) *backend.DataResponse {
 
-	resultsJSON, _ := json.MarshalIndent(results, "", "  ")
-	log.DefaultLogger.Debug("FormatFacetedTimeseriesResults Result count: %d\nResults:\n%s",
-		len(results.Results), string(resultsJSON))
+	log.DefaultLogger.Debug("FormatFacetedTimeseriesResults",
+		"resultCount", len(results.Results))
 
 	if !isFacetedTimeseriesQueryMulti(results) {
 		resp := &backend.DataResponse{}
@@ -947,21 +1366,21 @@ func FormatFacetedTimeseriesResults(results *nrdb.NRDBResultContainerMultiResult
 	// First check Results as it's the preferred location for faceted timeseries
 	if len(results.Results) > 0 {
 		actualResults = results.Results
-		log.DefaultLogger.Debug("Using Results with %d entries", len(actualResults))
+		log.DefaultLogger.Debug("Using Results", "entryCount", len(actualResults))
 		// Debug facet values
 		for i, result := range actualResults {
 			if facetVal, ok := result["facet"]; ok {
-				log.DefaultLogger.Debug("Results[%d] facet: %v", i, facetVal)
+				log.DefaultLogger.Debug("Results facet", "index", i, "facet", facetVal)
 			}
 		}
 	} else {
 		// Fallback to OtherResult if Results is empty
 		actualResults = results.OtherResult
-		log.DefaultLogger.Debug("Using OtherResult with %d entries", len(actualResults))
+		log.DefaultLogger.Debug("Using OtherResult", "entryCount", len(actualResults))
 		// Debug facet values
 		for i, result := range actualResults {
 			if facetVal, ok := result["facet"]; ok {
-				log.DefaultLogger.Debug("OtherResult[%d] facet: %v", i, facetVal)
+				log.DefaultLogger.Debug("OtherResult facet", "index", i, "facet", facetVal)
 			}
 		}
 	}
@@ -987,81 +1406,56 @@ func FormatFacetedTimeseriesResults(results *nrdb.NRDBResultContainerMultiResult
 	return formatFacetedAggregationQuery(standardResults, query, facetNames)
 }
 
-// isAggregationField checks if a field name represents an aggregation function result
+// isAggregationField checks if a field name represents a metric/aggregation result.
+// Uses a blacklist approach: any field that isn't an internal/system field is considered
+// an aggregation field. This supports arbitrary user-defined aliases (e.g., 'Total', 'My Metric').
 func isAggregationField(fieldName string) bool {
-	// Basic aggregation prefixes
-	aggregationPrefixes := []string{
-		"average.", "sum.", "min.", "max.", "count", "uniqueCount.", "latest.", "earliest.",
-		"median.", "percentile.", "rate.", "apdex.", "histogram.", "uniques.",
-		"getField.", "round.", "percentage.", "stddev.", "variance.", "filter.",
+	// Exclude known internal/system fields that are never metrics
+	internalFields := map[string]bool{
+		"facet":            true,
+		"inspectedCount":   true,
+		"timestamp":        true,
+		"beginTimeSeconds": true,
+		"endTimeSeconds":   true,
 	}
 
-	// Check for exact matches (count is standalone)
-	exactMatches := []string{
-		"count",
+	if internalFields[fieldName] {
+		return false
 	}
 
-	// Common aliases and custom field names that are aggregations
-	aliasMatches := []string{
-		"Error Rate", "Success Rate", "Error %", "ErrorCount", "SuccessCount",
-		"Avg Duration", "Successes", "Errors", "f", "s", "t", "score", "duration",
-		"BucketMin", "BucketMax",
-	}
-
-	// Check exact matches first
-	for _, exact := range exactMatches {
-		if fieldName == exact {
-			return true
-		}
-	}
-
-	// Check alias matches
-	for _, alias := range aliasMatches {
-		if fieldName == alias {
-			return true
-		}
-	}
-
-	// Check prefixes
-	for _, prefix := range aggregationPrefixes {
-		if strings.HasPrefix(fieldName, prefix) {
-			return true
-		}
-	}
-
-	return false
+	// Any non-internal field is treated as a metric/aggregation field
+	return true
 }
 
-// detectFieldType analyzes a field across all results to determine the best data type
+// detectFieldType analyzes a field across all results to determine the best data type.
+// Uses field name prefixes for known NR types, then inspects actual values for all others.
 func detectFieldType(results []nrdb.NRDBResult, fieldName string) string {
-	// Check if it's an aggregation field first
-	if isAggregationField(fieldName) {
-		// Special handling for specific aggregation types
-		if strings.HasPrefix(fieldName, "histogram.") {
-			return "array" // histogram returns array of numbers
+	// Handle known NR field name patterns that have specific types
+	if strings.HasPrefix(fieldName, "histogram.") {
+		return "array"
+	}
+	if strings.HasPrefix(fieldName, "uniques.") {
+		return "array"
+	}
+	if strings.HasPrefix(fieldName, "percentile.") {
+		parts := strings.Split(fieldName, ".")
+		if len(parts) >= 3 {
+			return "number" // specific percentile like "percentile.duration.95"
 		}
-		if strings.HasPrefix(fieldName, "uniques.") {
-			return "array" // uniques returns array of strings/values
+		return "object" // generic percentile object like "percentile.duration"
+	}
+	if strings.HasPrefix(fieldName, "apdex.") {
+		parts := strings.Split(fieldName, ".")
+		if len(parts) >= 3 {
+			return "number" // specific apdex field like "apdex.duration.score"
 		}
-		if strings.HasPrefix(fieldName, "percentile.") {
-			// Check if it's a specific percentile (e.g., percentile.duration.95) vs generic percentile object
-			// If the field name has more than 2 dots after "percentile", it's likely a specific percentile value
-			parts := strings.Split(fieldName, ".")
-			if len(parts) >= 3 {
-				// This is a specific percentile like "percentile.duration.95" - treat as number
-				return "number"
-			}
-			// Generic percentile field - treat as object
-			return "object"
-		}
-		if strings.HasPrefix(fieldName, "earliest.timestamp") || strings.HasPrefix(fieldName, "latest.timestamp") {
-			return "timestamp" // timestamp fields
-		}
-		// Default for other aggregations is numeric
-		return "number"
+		return "object" // generic apdex object like "apdex.duration"
+	}
+	if strings.HasPrefix(fieldName, "earliest.timestamp") || strings.HasPrefix(fieldName, "latest.timestamp") {
+		return "timestamp"
 	}
 
-	// For non-aggregation fields, scan all results to determine type
+	// For all other fields, scan actual values to determine type
 	var foundTypes = make(map[string]bool)
 
 	for _, result := range results {
@@ -1115,7 +1509,14 @@ func formatStandardQueryMulti(results *nrdb.NRDBResultContainerMultiResultCustom
 
 	fieldNames := extractFieldNamesMulti(results)
 	times := createTimeFieldMulti(results, query)
-	frame.Fields = append(frame.Fields, data.NewField(utils.TimeFieldName, nil, times))
+	timeField := data.NewField(utils.TimeFieldName, nil, times)
+	// Convert multi-result Results to standard NRDBResult slice for interval calculation
+	standardResults := make([]nrdb.NRDBResult, len(results.Results))
+	for i, r := range results.Results {
+		standardResults[i] = r
+	}
+	setTimeFieldInterval(timeField, calculateBucketIntervalMs(standardResults))
+	frame.Fields = append(frame.Fields, timeField)
 	addDataFieldsMulti(frame, results, fieldNames)
 	resp.Frames = append(resp.Frames, frame)
 	return resp
@@ -1211,17 +1612,16 @@ func addDataFieldsMulti(frame *data.Frame, results *nrdb.NRDBResultContainerMult
 				frame.Fields = append(frame.Fields, data.NewField(fieldName, nil, values))
 
 			case "array":
-				// Handle arrays (like histogram, uniques) - convert to JSON string for display
+				// Handle arrays (like histogram, uniques) - convert to comma-separated string
 				values := make([]string, len(results.Results))
 				for i, result := range results.Results {
 					if result[fieldName] != nil {
 						if arrayVal, ok := result[fieldName].([]interface{}); ok {
-							// Convert array to JSON string for better display
-							if jsonBytes, err := json.Marshal(arrayVal); err == nil {
-								values[i] = string(jsonBytes)
-							} else {
-								values[i] = fmt.Sprintf("%v", arrayVal)
+							parts := make([]string, len(arrayVal))
+							for j, elem := range arrayVal {
+								parts[j] = fmt.Sprintf("%v", elem)
 							}
+							values[i] = strings.Join(parts, ", ")
 						} else {
 							values[i] = fmt.Sprintf("%v", result[fieldName])
 						}

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -79,11 +79,9 @@ func TestFormatQueryResults(t *testing.T) {
 			},
 			query: query,
 			validate: func(t *testing.T, resp *backend.DataResponse) {
-				require.Len(t, resp.Frames, 2)
+				require.Len(t, resp.Frames, 1)
 				assert.Equal(t, "count", resp.Frames[0].Name)
 				assert.Equal(t, data.VisType(data.VisTypeTable), resp.Frames[0].Meta.PreferredVisualization)
-				assert.Equal(t, utils.CountTimeSeriesFrameName, resp.Frames[1].Name)
-				assert.Equal(t, data.VisTypeGraph, resp.Frames[1].Meta.PreferredVisualization)
 			},
 		},
 		{
@@ -2595,7 +2593,7 @@ func TestHandlePercentileField_Formatter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			frame := data.NewFrame("test")
-			handlePercentileField(frame, tt.results, tt.fieldName)
+			handleNestedObjectField(frame, tt.results, tt.fieldName)
 
 			assert.Equal(t, tt.expectedFields, len(frame.Fields), "Incorrect number of fields created")
 			if tt.fieldAssertions != nil {
@@ -3547,7 +3545,7 @@ func TestHandlePercentileFieldExtended(t *testing.T) {
 		}
 
 		// Process percentiles
-		handlePercentileField(frame, results, "percentile.duration")
+		handleNestedObjectField(frame, results, "percentile.duration")
 
 		// Should have one field for the 95th percentile
 		assert.Equal(t, 1, len(frame.Fields))
@@ -3582,7 +3580,7 @@ func TestHandlePercentileFieldExtended(t *testing.T) {
 		}
 
 		// Process percentiles
-		handlePercentileField(frame, results, "percentile.duration")
+		handleNestedObjectField(frame, results, "percentile.duration")
 
 		// Should have three fields, one for each percentile
 		assert.Equal(t, 3, len(frame.Fields))
@@ -3622,7 +3620,7 @@ func TestHandlePercentileFieldExtended(t *testing.T) {
 		}
 
 		// Process percentiles
-		handlePercentileField(frame, results, "percentile.duration")
+		handleNestedObjectField(frame, results, "percentile.duration")
 
 		// Should have one field
 		assert.Equal(t, 1, len(frame.Fields))
@@ -3649,7 +3647,7 @@ func TestHandlePercentileFieldExtended(t *testing.T) {
 		}
 
 		// Process percentiles
-		handlePercentileField(frame, results, "percentile.duration")
+		handleNestedObjectField(frame, results, "percentile.duration")
 
 		// Should have correctly parsed the string value
 		assert.Equal(t, 1, len(frame.Fields))
@@ -4122,4 +4120,164 @@ func TestFormatFacetedTimeseriesQueryBasic(t *testing.T) {
 	assert.NotNil(t, response)
 	assert.Nil(t, response.Error)
 	assert.Equal(t, 2, len(response.Frames))
+}
+
+func TestIsCompareWithQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  *nrdb.NRDBResultContainer
+		expected bool
+	}{
+		{
+			name: "COMPARE WITH query",
+			results: &nrdb.NRDBResultContainer{
+				Results: []nrdb.NRDBResult{
+					{"comparison": "current", "Valid Auth": 99.27, "Total Requests": float64(22553411)},
+					{"comparison": "previous", "Valid Auth": 99.25, "Total Requests": float64(22573808)},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "regular query without comparison",
+			results: &nrdb.NRDBResultContainer{
+				Results: []nrdb.NRDBResult{
+					{"count": float64(100)},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "single result with comparison field",
+			results: &nrdb.NRDBResultContainer{
+				Results: []nrdb.NRDBResult{
+					{"comparison": "current", "count": float64(100)},
+				},
+			},
+			expected: false, // needs at least 2 results
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCompareWithQuery(tt.results)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatCompareWithQuery(t *testing.T) {
+	now := time.Now()
+	query := backend.DataQuery{
+		TimeRange: backend.TimeRange{
+			From: now.Add(-1 * time.Hour),
+			To:   now,
+		},
+	}
+
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{
+				"comparison":     "current",
+				"Valid Auth":     99.27,
+				"Denied Request": 0.73,
+				"Total Requests": float64(22553411),
+			},
+			{
+				"comparison":     "previous",
+				"Valid Auth":     99.25,
+				"Denied Request": 0.75,
+				"Total Requests": float64(22573808),
+			},
+		},
+	}
+
+	response := formatCompareWithQuery(results, query)
+
+	require.NotNil(t, response)
+	require.Nil(t, response.Error)
+	require.Equal(t, 2, len(response.Frames), "should have current and previous frames")
+
+	// Current frame should have numeric fields without labels
+	currentFrame := response.Frames[0]
+	assert.Equal(t, "current", currentFrame.Name)
+	// time + 3 metric fields
+	assert.GreaterOrEqual(t, len(currentFrame.Fields), 4)
+
+	// Previous frame should have fields with "previous" label
+	previousFrame := response.Frames[1]
+	assert.Equal(t, "previous", previousFrame.Name)
+	assert.GreaterOrEqual(t, len(previousFrame.Fields), 4)
+
+	// Check that previous frame fields have comparison label
+	for _, field := range previousFrame.Fields {
+		if field.Name != "time" {
+			labels := field.Labels
+			assert.Equal(t, "previous", labels["comparison"])
+		}
+	}
+}
+
+func TestFormatCompareWithQuery_RoutedCorrectly(t *testing.T) {
+	now := time.Now()
+	query := backend.DataQuery{
+		TimeRange: backend.TimeRange{
+			From: now.Add(-1 * time.Hour),
+			To:   now,
+		},
+	}
+
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"comparison": "current", "count": float64(100)},
+			{"comparison": "previous", "count": float64(90)},
+		},
+	}
+
+	response := FormatQueryResults(results, query)
+
+	require.NotNil(t, response)
+	require.Nil(t, response.Error)
+	require.Equal(t, 2, len(response.Frames))
+	assert.Equal(t, "current", response.Frames[0].Name)
+	assert.Equal(t, "previous", response.Frames[1].Name)
+}
+
+func TestArrayFieldsRenderedAsCommaSeparated(t *testing.T) {
+	now := time.Now()
+	query := backend.DataQuery{
+		TimeRange: backend.TimeRange{
+			From: now.Add(-1 * time.Hour),
+			To:   now,
+		},
+	}
+
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{
+				"access-control-allow-methods": []interface{}{"GET", "POST", "PUT"},
+			},
+		},
+	}
+
+	response := FormatQueryResults(results, query)
+
+	require.NotNil(t, response)
+	require.Nil(t, response.Error)
+	require.GreaterOrEqual(t, len(response.Frames), 1)
+
+	// Find the array field
+	frame := response.Frames[0]
+	found := false
+	for _, field := range frame.Fields {
+		if field.Name == "access-control-allow-methods" {
+			found = true
+			require.Equal(t, 1, field.Len())
+			val := field.At(0)
+			strVal, ok := val.(string)
+			require.True(t, ok, "array field should be string type")
+			assert.Equal(t, "GET, POST, PUT", strVal)
+		}
+	}
+	assert.True(t, found, "should find access-control-allow-methods field")
 }

--- a/pkg/formatter/logs.go
+++ b/pkg/formatter/logs.go
@@ -1,0 +1,198 @@
+// Package formatter — log-specific formatting for Grafana's Logs panel.
+// Converts New Relic Log event results into Grafana log-lines data frames
+// with proper metadata so they render in the Logs panel with severity
+// color-coding, expandable labels, and log search.
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrdb"
+)
+
+// Fields consumed by the log formatter and excluded from the labels JSON.
+var logConsumedFields = map[string]bool{
+	// Timestamp
+	"timestamp": true,
+	// Message variants
+	"message": true, "log_message": true, "messageBody": true, "msg": true,
+	// Severity variants
+	"level": true, "severity": true, "log_severity": true, "log.level": true,
+	// ID fields
+	"messageId": true, "nr.guid": true,
+	// Internal NR metadata
+	"inspectedCount": true, "beginTimeSeconds": true, "endTimeSeconds": true,
+	"eventType": true,
+}
+
+// severityAliases maps non-canonical severity strings to Grafana canonical levels.
+var severityAliases = map[string]string{
+	"fatal":         "critical",
+	"emerg":         "critical",
+	"emergency":     "critical",
+	"alert":         "critical",
+	"crit":          "critical",
+	"err":           "error",
+	"warn":          "warning",
+	"notice":        "info",
+	"informational": "info",
+	"dbug":          "debug",
+}
+
+// FormatLogResults converts NR Log query results into a Grafana log-lines
+// data frame with proper metadata for the Logs panel visualization.
+func FormatLogResults(results *nrdb.NRDBResultContainer, query backend.DataQuery, executedQuery string) *backend.DataResponse {
+	resp := &backend.DataResponse{}
+
+	if len(results.Results) == 0 {
+		log.DefaultLogger.Debug("Log formatter: no results")
+		return resp
+	}
+
+	n := len(results.Results)
+
+	timestamps := make([]time.Time, n)
+	bodies := make([]string, n)
+	severities := make([]string, n)
+	ids := make([]string, n)
+	labelsList := make([]json.RawMessage, n)
+
+	for i, result := range results.Results {
+		timestamps[i] = extractLogTimestamp(result)
+		bodies[i] = extractLogBody(result)
+		severities[i] = extractLogSeverity(result)
+		ids[i] = generateLogID(i, result)
+		labelsList[i] = buildLogLabels(result)
+	}
+
+	frame := data.NewFrame("log-lines",
+		data.NewField("timestamp", nil, timestamps),
+		data.NewField("body", nil, bodies),
+		data.NewField("severity", nil, severities),
+		data.NewField("id", nil, ids),
+		data.NewField("labels", nil, labelsList),
+	)
+
+	frame.Meta = &data.FrameMeta{
+		Type:                   data.FrameTypeLogLines,
+		PreferredVisualization: data.VisTypeLogs,
+		ExecutedQueryString:    executedQuery,
+		Custom: map[string]interface{}{
+			"limit": n,
+		},
+	}
+
+	log.DefaultLogger.Debug("Log formatter: built frame", "rows", n)
+	resp.Frames = append(resp.Frames, frame)
+	return resp
+}
+
+// extractLogTimestamp converts the NR timestamp field (epoch milliseconds) to time.Time.
+func extractLogTimestamp(result map[string]interface{}) time.Time {
+	if ts, ok := result["timestamp"].(float64); ok && ts > 0 {
+		return time.Unix(0, int64(ts)*int64(time.Millisecond))
+	}
+	return time.Now()
+}
+
+// extractLogBody returns the log message body, checking multiple NR field names.
+func extractLogBody(result map[string]interface{}) string {
+	for _, key := range []string{"message", "log_message", "messageBody", "msg"} {
+		if val, ok := result[key]; ok {
+			if s, ok := val.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// extractLogSeverity returns a normalized severity string for Grafana color-coding.
+func extractLogSeverity(result map[string]interface{}) string {
+	raw := ""
+	for _, key := range []string{"level", "severity", "log_severity", "log.level"} {
+		if val, ok := result[key]; ok {
+			if s, ok := val.(string); ok && s != "" {
+				raw = s
+				break
+			}
+		}
+	}
+	if raw == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(strings.TrimSpace(raw))
+
+	// Check alias map first
+	if canonical, ok := severityAliases[lower]; ok {
+		return canonical
+	}
+
+	// Already a canonical Grafana level?
+	switch lower {
+	case "critical", "error", "warning", "info", "debug", "trace", "unknown":
+		return lower
+	}
+
+	return lower
+}
+
+// generateLogID creates a unique ID for a log line.
+func generateLogID(index int, result map[string]interface{}) string {
+	// Prefer NR-provided IDs
+	for _, key := range []string{"messageId", "nr.guid"} {
+		if val, ok := result[key]; ok {
+			if s, ok := val.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+
+	// Fallback: index + timestamp
+	ts := extractLogTimestamp(result)
+	return fmt.Sprintf("%d-%d", index, ts.UnixNano())
+}
+
+// buildLogLabels creates a JSON object of all attributes not consumed by other fields.
+// Nil values are skipped, and complex values are converted to strings to ensure
+// Grafana can always display them in the log detail view.
+func buildLogLabels(result map[string]interface{}) json.RawMessage {
+	labels := make(map[string]interface{})
+	for k, v := range result {
+		if logConsumedFields[k] || v == nil {
+			continue
+		}
+		// Flatten complex types to strings for reliable display
+		switch val := v.(type) {
+		case string, float64, bool:
+			labels[k] = val
+		case int, int64:
+			labels[k] = val
+		default:
+			// Arrays, maps, etc. — marshal to string
+			if b, err := json.Marshal(val); err == nil {
+				labels[k] = string(b)
+			} else {
+				labels[k] = fmt.Sprintf("%v", val)
+			}
+		}
+	}
+
+	if len(labels) == 0 {
+		return json.RawMessage("{}")
+	}
+
+	b, err := json.Marshal(labels)
+	if err != nil {
+		log.DefaultLogger.Error("Failed to marshal log labels", "error", err)
+		return json.RawMessage("{}")
+	}
+	return b
+}

--- a/pkg/formatter/logs_test.go
+++ b/pkg/formatter/logs_test.go
@@ -1,0 +1,282 @@
+package formatter
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrdb"
+)
+
+func TestFormatLogResults_BasicFormatting(t *testing.T) {
+	now := float64(time.Now().UnixMilli())
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"timestamp": now, "message": "Request started", "level": "info", "hostname": "web-1", "service_name": "api"},
+			{"timestamp": now + 1000, "message": "Request failed", "level": "error", "hostname": "web-2", "service_name": "api"},
+			{"timestamp": now + 2000, "message": "Debug trace", "level": "debug", "hostname": "web-1", "service_name": "worker"},
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A", TimeRange: backend.TimeRange{}}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log SINCE 1 hour ago")
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if len(resp.Frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(resp.Frames))
+	}
+
+	frame := resp.Frames[0]
+
+	// Check frame name
+	if frame.Name != "log-lines" {
+		t.Errorf("expected frame name 'log-lines', got '%s'", frame.Name)
+	}
+
+	// Check field count
+	if len(frame.Fields) != 5 {
+		t.Fatalf("expected 5 fields, got %d", len(frame.Fields))
+	}
+
+	// Check field names
+	expectedFields := []string{"timestamp", "body", "severity", "id", "labels"}
+	for i, name := range expectedFields {
+		if frame.Fields[i].Name != name {
+			t.Errorf("field %d: expected name '%s', got '%s'", i, name, frame.Fields[i].Name)
+		}
+	}
+
+	// Check metadata
+	if frame.Meta == nil {
+		t.Fatal("expected frame meta, got nil")
+	}
+	if frame.Meta.Type != data.FrameTypeLogLines {
+		t.Errorf("expected frame type %s, got %s", data.FrameTypeLogLines, frame.Meta.Type)
+	}
+	if frame.Meta.PreferredVisualization != data.VisTypeLogs {
+		t.Errorf("expected preferred vis %s, got %s", data.VisTypeLogs, frame.Meta.PreferredVisualization)
+	}
+	if frame.Meta.ExecutedQueryString != "SELECT * FROM Log SINCE 1 hour ago" {
+		t.Errorf("expected executed query in meta, got '%s'", frame.Meta.ExecutedQueryString)
+	}
+
+	// Check body values
+	bodies := frame.Fields[1] // body field
+	if bodies.Len() != 3 {
+		t.Fatalf("expected 3 body values, got %d", bodies.Len())
+	}
+	if bodies.At(0) != "Request started" {
+		t.Errorf("expected 'Request started', got '%v'", bodies.At(0))
+	}
+	if bodies.At(1) != "Request failed" {
+		t.Errorf("expected 'Request failed', got '%v'", bodies.At(1))
+	}
+
+	// Check severity values
+	severities := frame.Fields[2] // severity field
+	if severities.At(0) != "info" {
+		t.Errorf("expected severity 'info', got '%v'", severities.At(0))
+	}
+	if severities.At(1) != "error" {
+		t.Errorf("expected severity 'error', got '%v'", severities.At(1))
+	}
+	if severities.At(2) != "debug" {
+		t.Errorf("expected severity 'debug', got '%v'", severities.At(2))
+	}
+}
+
+func TestFormatLogResults_AlternativeFieldNames(t *testing.T) {
+	now := float64(time.Now().UnixMilli())
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"timestamp": now, "log_message": "Alt message", "log_severity": "WARN"},
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	frame := resp.Frames[0]
+	body := frame.Fields[1].At(0).(string)
+	if body != "Alt message" {
+		t.Errorf("expected body from log_message, got '%s'", body)
+	}
+
+	severity := frame.Fields[2].At(0).(string)
+	if severity != "warning" {
+		t.Errorf("expected normalized severity 'warning', got '%s'", severity)
+	}
+}
+
+func TestFormatLogResults_MissingFields(t *testing.T) {
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"hostname": "web-1"}, // no timestamp, no message, no level
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if len(resp.Frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(resp.Frames))
+	}
+
+	frame := resp.Frames[0]
+	body := frame.Fields[1].At(0).(string)
+	if body != "" {
+		t.Errorf("expected empty body, got '%s'", body)
+	}
+	severity := frame.Fields[2].At(0).(string)
+	if severity != "" {
+		t.Errorf("expected empty severity, got '%s'", severity)
+	}
+}
+
+func TestFormatLogResults_EmptyResults(t *testing.T) {
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if len(resp.Frames) != 0 {
+		t.Errorf("expected 0 frames for empty results, got %d", len(resp.Frames))
+	}
+}
+
+func TestFormatLogResults_LabelsExcludeConsumedFields(t *testing.T) {
+	now := float64(time.Now().UnixMilli())
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{
+				"timestamp":    now,
+				"message":      "Test log",
+				"level":        "info",
+				"hostname":     "web-1",
+				"entity.name":  "my-service",
+				"logtype":      "application",
+				"custom_field": "custom_value",
+			},
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	frame := resp.Frames[0]
+	labelsRaw := frame.Fields[4].At(0).(json.RawMessage)
+
+	var labels map[string]interface{}
+	if err := json.Unmarshal(labelsRaw, &labels); err != nil {
+		t.Fatalf("failed to parse labels JSON: %v", err)
+	}
+
+	// Should contain non-consumed fields
+	if _, ok := labels["hostname"]; !ok {
+		t.Error("expected 'hostname' in labels")
+	}
+	if _, ok := labels["entity.name"]; !ok {
+		t.Error("expected 'entity.name' in labels")
+	}
+	if _, ok := labels["logtype"]; !ok {
+		t.Error("expected 'logtype' in labels")
+	}
+	if _, ok := labels["custom_field"]; !ok {
+		t.Error("expected 'custom_field' in labels")
+	}
+
+	// Should NOT contain consumed fields
+	if _, ok := labels["timestamp"]; ok {
+		t.Error("'timestamp' should be excluded from labels")
+	}
+	if _, ok := labels["message"]; ok {
+		t.Error("'message' should be excluded from labels")
+	}
+	if _, ok := labels["level"]; ok {
+		t.Error("'level' should be excluded from labels")
+	}
+}
+
+func TestFormatLogResults_UniqueIDs(t *testing.T) {
+	now := float64(time.Now().UnixMilli())
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"timestamp": now, "message": "log 1"},
+			{"timestamp": now + 1, "message": "log 2"},
+			{"timestamp": now + 2, "message": "log 3"},
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	frame := resp.Frames[0]
+	ids := frame.Fields[3] // id field
+
+	seen := make(map[string]bool)
+	for i := 0; i < ids.Len(); i++ {
+		id := ids.At(i).(string)
+		if id == "" {
+			t.Errorf("row %d: expected non-empty ID", i)
+		}
+		if seen[id] {
+			t.Errorf("row %d: duplicate ID '%s'", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestFormatLogResults_IDFromNRGuid(t *testing.T) {
+	results := &nrdb.NRDBResultContainer{
+		Results: []nrdb.NRDBResult{
+			{"timestamp": float64(time.Now().UnixMilli()), "message": "test", "nr.guid": "abc-123-def"},
+		},
+	}
+
+	query := backend.DataQuery{RefID: "A"}
+	resp := FormatLogResults(results, query, "SELECT * FROM Log")
+
+	id := resp.Frames[0].Fields[3].At(0).(string)
+	if id != "abc-123-def" {
+		t.Errorf("expected ID 'abc-123-def' from nr.guid, got '%s'", id)
+	}
+}
+
+func TestExtractLogSeverity_Normalization(t *testing.T) {
+	tests := []struct {
+		input    map[string]interface{}
+		expected string
+	}{
+		{map[string]interface{}{"level": "INFO"}, "info"},
+		{map[string]interface{}{"level": "ERROR"}, "error"},
+		{map[string]interface{}{"level": "WARN"}, "warning"},
+		{map[string]interface{}{"level": "warn"}, "warning"},
+		{map[string]interface{}{"level": "FATAL"}, "critical"},
+		{map[string]interface{}{"level": "crit"}, "critical"},
+		{map[string]interface{}{"level": "emerg"}, "critical"},
+		{map[string]interface{}{"level": "err"}, "error"},
+		{map[string]interface{}{"level": "notice"}, "info"},
+		{map[string]interface{}{"level": "DEBUG"}, "debug"},
+		{map[string]interface{}{"severity": "warning"}, "warning"},
+		{map[string]interface{}{}, ""},
+	}
+
+	for _, tt := range tests {
+		got := extractLogSeverity(tt.input)
+		if got != tt.expected {
+			t.Errorf("extractLogSeverity(%v) = '%s', expected '%s'", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/pkg/formatter/universal.go
+++ b/pkg/formatter/universal.go
@@ -1,0 +1,669 @@
+// Package formatter handles the conversion of New Relic API responses
+// into Grafana data frames using a universal, metadata-driven approach.
+package formatter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// FlexibleResults handles JSON fields that may be either a single object or an
+// array of objects. The New Relic API returns OtherResult/TotalResult as a
+// single map for non-TIMESERIES FACET queries, but as an array for TIMESERIES
+// FACET queries. This type normalises both shapes into []map[string]interface{}.
+type FlexibleResults []map[string]interface{}
+
+func (f *FlexibleResults) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	// Array → unmarshal directly
+	if data[0] == '[' {
+		var arr []map[string]interface{}
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return err
+		}
+		*f = arr
+		return nil
+	}
+
+	// Single object → wrap in a slice
+	if data[0] == '{' {
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return err
+		}
+		*f = []map[string]interface{}{obj}
+		return nil
+	}
+
+	return fmt.Errorf("unexpected JSON type for FlexibleResults: %c", data[0])
+}
+
+// NormalizedDataPoint represents a single data point after normalization
+type NormalizedDataPoint struct {
+	Timestamp      time.Time
+	FacetValues    map[string]string    // Facet dimension values
+	Metrics        map[string]float64   // All metric values (flattened)
+	IntervalMs     float64              // Bucket interval in milliseconds (0 if unknown)
+}
+
+// UniversalResponse is a generic structure to handle any New Relic response
+type UniversalResponse struct {
+	Results      FlexibleResults  `json:"Results"`
+	OtherResult  FlexibleResults  `json:"OtherResult"`
+	TotalResult  FlexibleResults  `json:"TotalResult"`
+	Facets       []FacetGroup     `json:"facets"`
+	Metadata     ResponseMetadata `json:"metadata"`
+}
+
+// FacetGroup represents a faceted timeseries group
+type FacetGroup struct {
+	Name             interface{}          `json:"name"` // Can be string or array
+	BeginTimeSeconds int64                `json:"beginTimeSeconds"`
+	EndTimeSeconds   int64                `json:"endTimeSeconds"`
+	TimeSeries       []TimeSeriesBucket   `json:"timeSeries"`
+	Results          []map[string]interface{} `json:"results"`
+}
+
+// TimeSeriesBucket represents a single timeseries bucket
+type TimeSeriesBucket struct {
+	Results          []map[string]interface{} `json:"results"`
+	BeginTimeSeconds int64                    `json:"beginTimeSeconds"`
+	EndTimeSeconds   int64                    `json:"endTimeSeconds"`
+	InspectedCount   int                      `json:"inspectedCount"`
+}
+
+// ResponseMetadata holds metadata about the query
+type ResponseMetadata struct {
+	Facets   []string                `json:"facets"`
+	Facet    []string                `json:"facet"` // Can be array in some responses
+	Contents MetadataContents        `json:"contents"`
+}
+
+// MetadataContents describes the query structure
+type MetadataContents struct {
+	TimeSeries   TimeSeriesMetadata  `json:"timeSeries"`
+	Function     string              `json:"function"`
+	Messages     []interface{}       `json:"messages"`
+}
+
+// TimeSeriesMetadata describes timeseries query structure
+type TimeSeriesMetadata struct {
+	Contents []FunctionMetadata `json:"contents"`
+	Messages []interface{}      `json:"messages"`
+}
+
+// FunctionMetadata describes a function in the query
+type FunctionMetadata struct {
+	Function   string              `json:"function"`
+	Alias      string              `json:"alias"`
+	Attribute  string              `json:"attribute"`
+	Contents   *FunctionMetadata   `json:"contents,omitempty"`
+	Thresholds []float64           `json:"thresholds,omitempty"`
+}
+
+// FormatUniversal is the universal entry point for formatting any New Relic response
+func FormatUniversal(result interface{}, query backend.DataQuery) *backend.DataResponse {
+	resp := &backend.DataResponse{}
+
+	// Convert to JSON and back to generic structure for introspection
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		resp.Error = fmt.Errorf("failed to marshal result: %w", err)
+		log.DefaultLogger.Error("Failed to marshal result", "error", err)
+		return resp
+	}
+
+	log.DefaultLogger.Debug("Universal formatter received response", "size", len(jsonData))
+
+	var universal UniversalResponse
+	if err := json.Unmarshal(jsonData, &universal); err != nil {
+		resp.Error = fmt.Errorf("failed to unmarshal result: %w", err)
+		log.DefaultLogger.Error("Failed to unmarshal result", "error", err)
+		return resp
+	}
+
+	// Detect response structure and normalize
+	dataPoints := normalizeResponse(&universal)
+
+	if len(dataPoints) == 0 {
+		log.DefaultLogger.Debug("No data points extracted from response")
+		return resp
+	}
+
+	log.DefaultLogger.Debug("Normalized data points", "count", len(dataPoints))
+
+	// Extract facet names
+	facetNames := extractFacetNamesFromResponse(&universal)
+
+	// Build data frames
+	frames := buildUniversalFrames(dataPoints, facetNames, query)
+	resp.Frames = frames
+
+	log.DefaultLogger.Debug("Built data frames", "frameCount", len(frames))
+
+	return resp
+}
+
+// normalizeResponse converts any response format into normalized data points
+func normalizeResponse(resp *UniversalResponse) []NormalizedDataPoint {
+	var points []NormalizedDataPoint
+
+	// Case 1: Nested facet structure (e.g., cdfPercentage with FACET TIMESERIES)
+	if len(resp.Facets) > 0 {
+		log.DefaultLogger.Debug("Detected nested facet structure", "facetCount", len(resp.Facets))
+		points = normalizeNestedFacets(resp)
+	} else if len(resp.OtherResult) > 0 {
+		// Case 2: Multi-result structure (FACET + TIMESERIES)
+		log.DefaultLogger.Debug("Detected multi-result structure", "otherResultCount", len(resp.OtherResult))
+		points = normalizeMultiResult(resp)
+	} else if len(resp.Results) > 0 {
+		// Case 3: Standard results structure
+		log.DefaultLogger.Debug("Detected standard results structure", "resultCount", len(resp.Results))
+		points = normalizeStandardResults(resp)
+	}
+
+	return points
+}
+
+// normalizeNestedFacets handles the nested facet structure
+func normalizeNestedFacets(resp *UniversalResponse) []NormalizedDataPoint {
+	var points []NormalizedDataPoint
+
+	facetNames := extractFacetNamesFromResponse(resp)
+
+	// Extract aliases from metadata for proper metric naming
+	aliases := extractAliasesFromMetadata(resp)
+
+	for _, facetGroup := range resp.Facets {
+		// Extract facet values - handle both string and array
+		facetValues := extractFacetValuesFromName(facetGroup.Name, facetNames)
+
+		// Process timeseries buckets
+		for _, bucket := range facetGroup.TimeSeries {
+			timestamp := time.Unix(bucket.BeginTimeSeconds, 0)
+			var bucketIntervalMs float64
+			if bucket.EndTimeSeconds > bucket.BeginTimeSeconds {
+				bucketIntervalMs = float64(bucket.EndTimeSeconds-bucket.BeginTimeSeconds) * 1000
+			}
+
+			// Each result in the bucket is a separate metric (e.g., Errors, Success, Error %)
+			// Don't aggregate them - keep them separate
+			allMetrics := make(map[string]float64)
+
+			for resultIdx, result := range bucket.Results {
+				metrics := extractMetricsFromResult(result)
+
+				// Use aliases from metadata if available, otherwise use indexed naming
+				var metricPrefix string
+				if resultIdx < len(aliases) && aliases[resultIdx] != "" {
+					metricPrefix = aliases[resultIdx]
+				} else if len(bucket.Results) > 1 {
+					metricPrefix = fmt.Sprintf("metric_%d", resultIdx)
+				} else {
+					metricPrefix = ""
+				}
+
+				// Add metrics with appropriate naming
+				for key, value := range metrics {
+					var metricKey string
+					if metricPrefix != "" {
+						// Use alias as the metric name if we have one
+						// For count fields with aliases, use the alias directly
+						if key == "count" || key == "result" {
+							metricKey = metricPrefix
+						} else {
+							metricKey = fmt.Sprintf("%s.%s", metricPrefix, key)
+						}
+					} else {
+						metricKey = key
+					}
+					allMetrics[metricKey] = value
+				}
+			}
+
+			if len(allMetrics) > 0 {
+				points = append(points, NormalizedDataPoint{
+					Timestamp:   timestamp,
+					FacetValues: facetValues,
+					Metrics:     allMetrics,
+					IntervalMs:  bucketIntervalMs,
+				})
+			}
+		}
+
+		// Also handle non-timeseries facet results
+		if len(facetGroup.Results) > 0 {
+			timestamp := time.Now()
+			if facetGroup.BeginTimeSeconds > 0 {
+				timestamp = time.Unix(facetGroup.BeginTimeSeconds, 0)
+			}
+
+			for _, result := range facetGroup.Results {
+				metrics := extractMetricsFromResult(result)
+				if len(metrics) > 0 {
+					points = append(points, NormalizedDataPoint{
+						Timestamp:   timestamp,
+						FacetValues: facetValues,
+						Metrics:     metrics,
+					})
+				}
+			}
+		}
+	}
+
+	return points
+}
+
+// normalizeMultiResult handles the multi-result structure
+func normalizeMultiResult(resp *UniversalResponse) []NormalizedDataPoint {
+	var points []NormalizedDataPoint
+
+	// Use OtherResult which typically contains the faceted timeseries data
+	resultsToProcess := resp.OtherResult
+	if len(resultsToProcess) == 0 {
+		resultsToProcess = resp.Results
+	}
+
+	facetNames := extractFacetNamesFromResponse(resp)
+
+	for _, result := range resultsToProcess {
+		point := normalizeResultMap(result, facetNames)
+		points = append(points, point)
+	}
+
+	return points
+}
+
+// normalizeStandardResults handles the standard results structure
+func normalizeStandardResults(resp *UniversalResponse) []NormalizedDataPoint {
+	var points []NormalizedDataPoint
+
+	facetNames := extractFacetNamesFromResponse(resp)
+
+	for _, result := range resp.Results {
+		point := normalizeResultMap(result, facetNames)
+		points = append(points, point)
+	}
+
+	return points
+}
+
+// normalizeResultMap converts a single result map into a normalized data point
+func normalizeResultMap(result map[string]interface{}, facetNames []string) NormalizedDataPoint {
+	point := NormalizedDataPoint{
+		Timestamp:   extractTimestamp(result),
+		FacetValues: extractUniversalFacetValues(result, facetNames),
+		Metrics:     extractMetricsFromResult(result),
+		IntervalMs:  extractBucketIntervalMs(result),
+	}
+	return point
+}
+
+// extractBucketIntervalMs calculates the bucket interval in milliseconds from a result map
+func extractBucketIntervalMs(result map[string]interface{}) float64 {
+	beginTs, hasBegin := result["beginTimeSeconds"].(float64)
+	endTs, hasEnd := result["endTimeSeconds"].(float64)
+	if hasBegin && hasEnd && endTs > beginTs {
+		return (endTs - beginTs) * 1000
+	}
+	return 0
+}
+
+// extractTimestamp extracts timestamp from a result
+func extractTimestamp(result map[string]interface{}) time.Time {
+	// Try various timestamp fields
+	if ts, ok := result["timestamp"].(float64); ok {
+		return time.Unix(int64(ts/1000), 0)
+	}
+	if ts, ok := result["beginTimeSeconds"].(float64); ok {
+		return time.Unix(int64(ts), 0)
+	}
+	if ts, ok := result["endTimeSeconds"].(float64); ok {
+		return time.Unix(int64(ts), 0)
+	}
+	return time.Now()
+}
+
+// extractUniversalFacetValues extracts facet dimension values from a result
+func extractUniversalFacetValues(result map[string]interface{}, facetNames []string) map[string]string {
+	facetValues := make(map[string]string)
+
+	facetData, hasFacet := result["facet"]
+	if !hasFacet {
+		return facetValues
+	}
+
+	// Handle facet as array
+	if facetArray, ok := facetData.([]interface{}); ok {
+		for i, value := range facetArray {
+			if i < len(facetNames) {
+				facetValues[facetNames[i]] = fmt.Sprintf("%v", value)
+			} else {
+				facetValues[fmt.Sprintf("facet_%d", i)] = fmt.Sprintf("%v", value)
+			}
+		}
+	} else {
+		// Handle single facet value
+		if len(facetNames) > 0 {
+			facetValues[facetNames[0]] = fmt.Sprintf("%v", facetData)
+		} else {
+			facetValues["facet"] = fmt.Sprintf("%v", facetData)
+		}
+	}
+
+	return facetValues
+}
+
+// extractMetricsFromResult extracts all metric values from a result, flattening composite types
+func extractMetricsFromResult(result map[string]interface{}) map[string]float64 {
+	metrics := make(map[string]float64)
+
+	for key, value := range result {
+		// Skip internal/system fields
+		if isInternalField(key) {
+			continue
+		}
+
+		// Handle different value types
+		switch v := value.(type) {
+		case float64:
+			metrics[key] = v
+		case int:
+			metrics[key] = float64(v)
+		case int64:
+			metrics[key] = float64(v)
+		case map[string]interface{}:
+			// Flatten nested objects (apdex, cdfpercentages, percentiles, etc.)
+			flattenObject(key, v, metrics)
+		case []interface{}:
+			// Arrays (histogram, uniques) are handled by the standard formatter's addDataFields.
+			// The universal formatter's metric map is float64-only, so skip here.
+			continue
+		case string:
+			// Try to parse as number
+			if num, err := parseNumericString(v); err == nil {
+				metrics[key] = num
+			}
+		}
+	}
+
+	return metrics
+}
+
+// flattenObject flattens a nested object into separate metric fields
+func flattenObject(prefix string, obj map[string]interface{}, metrics map[string]float64) {
+	for key, value := range obj {
+		fieldName := fmt.Sprintf("%s.%s", prefix, key)
+
+		switch v := value.(type) {
+		case float64:
+			metrics[fieldName] = v
+		case int:
+			metrics[fieldName] = float64(v)
+		case int64:
+			metrics[fieldName] = float64(v)
+		case string:
+			if num, err := parseNumericString(v); err == nil {
+				metrics[fieldName] = num
+			}
+		case map[string]interface{}:
+			// Recursively flatten nested objects
+			flattenObject(fieldName, v, metrics)
+		}
+	}
+}
+
+// isInternalField checks if a field is an internal/system field that should be excluded
+func isInternalField(key string) bool {
+	internalFields := []string{
+		"beginTimeSeconds",
+		"endTimeSeconds",
+		"facet",
+		"inspectedCount",
+		"timestamp",
+	}
+
+	for _, internal := range internalFields {
+		if key == internal {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractAliasesFromMetadata extracts function aliases from metadata
+// Returns an array of aliases like ["Errors", "Success", "Error %"]
+func extractAliasesFromMetadata(resp *UniversalResponse) []string {
+	var aliases []string
+
+	// Check if we have timeseries metadata with contents
+	if resp.Metadata.Contents.TimeSeries.Contents != nil {
+		for _, content := range resp.Metadata.Contents.TimeSeries.Contents {
+			if content.Alias != "" {
+				aliases = append(aliases, content.Alias)
+			}
+		}
+	}
+
+	log.DefaultLogger.Debug("Extracted aliases from metadata", "aliases", aliases, "count", len(aliases))
+	return aliases
+}
+
+// extractFacetNamesFromResponse extracts facet names from metadata
+func extractFacetNamesFromResponse(resp *UniversalResponse) []string {
+	// Check Facets array first (for multi-facet queries)
+	if len(resp.Metadata.Facets) > 0 {
+		return resp.Metadata.Facets
+	}
+	// Check Facet field in metadata (for nested facet structure)
+	if len(resp.Metadata.Facet) > 0 {
+		// Facet can be a string or array
+		return resp.Metadata.Facet
+	}
+	return nil
+}
+
+// extractFacetValuesFromName extracts facet values from the name field
+// The name can be either a string, an array of strings, or an array with mixed types
+func extractFacetValuesFromName(name interface{}, facetNames []string) map[string]string {
+	facetValues := make(map[string]string)
+
+	switch v := name.(type) {
+	case string:
+		// Single string - use first facet name or default
+		if len(facetNames) > 0 {
+			facetValues[facetNames[0]] = v
+		} else {
+			facetValues["facet"] = v
+		}
+
+	case []interface{}:
+		// Array of values - map to facet names
+		for i, val := range v {
+			var strVal string
+			if val == nil {
+				strVal = "null"
+			} else {
+				strVal = fmt.Sprintf("%v", val)
+			}
+
+			if i < len(facetNames) {
+				facetValues[facetNames[i]] = strVal
+			} else {
+				facetValues[fmt.Sprintf("facet_%d", i)] = strVal
+			}
+		}
+
+	case []string:
+		// Array of strings
+		for i, val := range v {
+			if i < len(facetNames) {
+				facetValues[facetNames[i]] = val
+			} else {
+				facetValues[fmt.Sprintf("facet_%d", i)] = val
+			}
+		}
+
+	default:
+		// Fallback
+		facetValues["facet"] = fmt.Sprintf("%v", name)
+	}
+
+	return facetValues
+}
+
+// buildUniversalFrames builds Grafana data frames from normalized data points
+func buildUniversalFrames(points []NormalizedDataPoint, facetNames []string, query backend.DataQuery) []*data.Frame {
+	// Group points by facet values
+	grouped := groupPointsByFacet(points)
+
+	var frames []*data.Frame
+
+	for facetKey, facetPoints := range grouped {
+		// Sort points by timestamp
+		sortPointsByTime(facetPoints)
+
+		// Extract all unique metric names
+		metricNames := extractMetricNames(facetPoints)
+
+		// Create frame for this facet group
+		frame := createFrameFromPoints(facetKey, facetPoints, metricNames)
+		frames = append(frames, frame)
+	}
+
+	log.DefaultLogger.Debug("Built frames from normalized points", "frameCount", len(frames))
+
+	return frames
+}
+
+// groupPointsByFacet groups data points by their facet values
+func groupPointsByFacet(points []NormalizedDataPoint) map[string][]NormalizedDataPoint {
+	grouped := make(map[string][]NormalizedDataPoint)
+
+	for _, point := range points {
+		// Create a key from facet values
+		key := createFacetKey(point.FacetValues)
+		grouped[key] = append(grouped[key], point)
+	}
+
+	return grouped
+}
+
+// createFacetKey creates a unique key from facet values for grouping
+func createFacetKey(facetValues map[string]string) string {
+	if len(facetValues) == 0 {
+		return ""
+	}
+
+	// Sort keys for consistent ordering
+	var keys []string
+	for k := range facetValues {
+		keys = append(keys, k)
+	}
+
+	// For single facet, return just the value
+	if len(keys) == 1 {
+		return facetValues[keys[0]]
+	}
+
+	// For multiple facets, create composite key
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, facetValues[k]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// extractMetricNames extracts all unique metric names from points
+func extractMetricNames(points []NormalizedDataPoint) []string {
+	nameSet := make(map[string]bool)
+
+	for _, point := range points {
+		for name := range point.Metrics {
+			nameSet[name] = true
+		}
+	}
+
+	var names []string
+	for name := range nameSet {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// sortPointsByTime sorts data points by timestamp
+func sortPointsByTime(points []NormalizedDataPoint) {
+	// Simple bubble sort for now
+	for i := 0; i < len(points)-1; i++ {
+		for j := 0; j < len(points)-i-1; j++ {
+			if points[j].Timestamp.After(points[j+1].Timestamp) {
+				points[j], points[j+1] = points[j+1], points[j]
+			}
+		}
+	}
+}
+
+// createFrameFromPoints creates a data frame from normalized points
+func createFrameFromPoints(facetKey string, points []NormalizedDataPoint, metricNames []string) *data.Frame {
+	// Use facet key as frame name, or "response" if no facets
+	frameName := facetKey
+	if frameName == "" {
+		frameName = "response"
+	}
+
+	frame := data.NewFrame(frameName)
+
+	// Add time field with bucket interval
+	times := make([]time.Time, len(points))
+	for i, point := range points {
+		times[i] = point.Timestamp
+	}
+	timeField := data.NewField("time", nil, times)
+	// Use the interval from the first point that has one
+	for _, point := range points {
+		if point.IntervalMs > 0 {
+			if timeField.Config == nil {
+				timeField.Config = &data.FieldConfig{}
+			}
+			timeField.Config.Interval = point.IntervalMs
+			break
+		}
+	}
+	frame.Fields = append(frame.Fields, timeField)
+
+	// Get facet labels from first point
+	var labels map[string]string
+	if len(points) > 0 && len(points[0].FacetValues) > 0 {
+		labels = points[0].FacetValues
+	}
+
+	// Add metric fields
+	for _, metricName := range metricNames {
+		values := make([]*float64, len(points))
+
+		for i, point := range points {
+			if value, exists := point.Metrics[metricName]; exists {
+				values[i] = &value
+			}
+			// If metric doesn't exist in this point, leave as nil
+		}
+
+		field := data.NewField(metricName, labels, values)
+		frame.Fields = append(frame.Fields, field)
+	}
+
+	return frame
+}

--- a/pkg/handler/query_handler.go
+++ b/pkg/handler/query_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"newrelic-grafana-plugin/pkg/formatter"
@@ -41,6 +42,15 @@ func shouldUseEnhancedQuery(query string) bool {
 	hasFacet := strings.Contains(strings.ToUpper(query), "FACET")
 	hasTimeseries := strings.Contains(strings.ToUpper(query), "TIMESERIES")
 	return hasFacet && hasTimeseries
+}
+
+// logQueryRegex matches "FROM Log" as a standalone event type (not "FROM LogMessage" etc.)
+var logQueryRegex = regexp.MustCompile(`(?i)\bFROM\s+Log\b`)
+
+// IsLogQuery determines if the NRQL query targets the Log event type.
+// Exported for testing.
+func IsLogQuery(query string) bool {
+	return logQueryRegex.MatchString(query)
 }
 
 // NormalizeQuery cleans up NRQL queries to fix common issues:
@@ -102,6 +112,27 @@ func ExecuteNRQLQuery(ctx context.Context, executor nrdbiface.NRDBQueryExecutor,
 	return executor.QueryWithContext(ctx, accountID, nrql)
 }
 
+// injectTimeRange appends SINCE/UNTIL to the NRQL query using Grafana's time range
+// if the query doesn't already contain a SINCE clause. This ensures dashboards
+// respect the Grafana time picker automatically.
+func injectTimeRange(nrqlQuery string, timeRange backend.TimeRange) string {
+	upper := strings.ToUpper(nrqlQuery)
+	if strings.Contains(upper, "SINCE") || strings.Contains(upper, "COMPARE WITH") {
+		return nrqlQuery
+	}
+
+	fromMs := timeRange.From.UnixMilli()
+	toMs := timeRange.To.UnixMilli()
+
+	if fromMs > 0 && toMs > 0 {
+		injected := fmt.Sprintf("%s SINCE %d UNTIL %d", nrqlQuery, fromMs, toMs)
+		log.DefaultLogger.Debug("Injected Grafana time range into NRQL",
+			"from", timeRange.From, "to", timeRange.To, "query", injected)
+		return injected
+	}
+	return nrqlQuery
+}
+
 // checkFacetAndTimeseries logs if both FACET and TIMESERIES are present in the query
 func checkFacetAndTimeseries(query string) {
 	hasFacet := strings.Contains(strings.ToUpper(query), "FACET")
@@ -123,7 +154,7 @@ func HandleQuery(ctx context.Context, executor nrdbiface.NRDBQueryExecutor, conf
 		return resp
 	}
 
-	log.DefaultLogger.Debug("Processing query", "refId", query.RefID, "queryText", qm.QueryText, "configAccountID", config.Secrets.AccountId, "queryAccountID", qm.AccountID)
+	log.DefaultLogger.Debug("Processing query", "refId", query.RefID)
 
 	// Check if query is empty
 	if qm.QueryText == "" {
@@ -135,6 +166,9 @@ func HandleQuery(ctx context.Context, executor nrdbiface.NRDBQueryExecutor, conf
 	// Normalize the query by removing line breaks that cause issues
 	nrqlQueryText := NormalizeQuery(qm.QueryText)
 
+	// Auto-inject Grafana time range if no SINCE clause present
+	nrqlQueryText = injectTimeRange(nrqlQueryText, query.TimeRange)
+
 	accountID := config.Secrets.AccountId
 	if qm.AccountID > 0 {
 		accountID = qm.AccountID
@@ -143,25 +177,69 @@ func HandleQuery(ctx context.Context, executor nrdbiface.NRDBQueryExecutor, conf
 	results, err := ExecuteNRQLQuery(ctx, executor, accountID, nrqlQueryText)
 	if err != nil {
 		resp.Error = fmt.Errorf("NRQL query execution failed: %w", err)
-		log.DefaultLogger.Error("NRQL query execution failed", "refId", query.RefID, "query", nrqlQueryText, "accountID", accountID, "error", err)
+		log.DefaultLogger.Error("NRQL query execution failed", "refId", query.RefID, "error", err)
 		return resp
 	}
 
-	// DEBUG: Log the actual response structure to understand the issue
-	if resultsJSON, err := json.MarshalIndent(results, "", "  "); err == nil {
-		log.DefaultLogger.Debug("Raw API response", "refId", query.RefID, "type", fmt.Sprintf("%T", results), "response", string(resultsJSON))
-	}
+	log.DefaultLogger.Debug("Query executed", "refId", query.RefID, "responseType", fmt.Sprintf("%T", results))
 
+	// First, try legacy formatters for known response types
+	// Only use universal formatter as a fallback for unhandled cases
 	switch r := results.(type) {
 	case *nrdb.NRDBResultContainer:
+		// Route log queries to the log formatter for proper Logs panel rendering
+		if IsLogQuery(nrqlQueryText) {
+			log.DefaultLogger.Debug("Using log formatter", "refId", query.RefID)
+			return formatter.FormatLogResults(r, query, nrqlQueryText)
+		}
+
 		log.DefaultLogger.Debug("Using standard formatter", "refId", query.RefID)
-		return formatter.FormatQueryResults(r, query)
+		legacyResp := formatter.FormatQueryResults(r, query)
+
+		// If legacy formatter succeeded, use it
+		if legacyResp.Error == nil && len(legacyResp.Frames) > 0 {
+			log.DefaultLogger.Debug("Standard formatter succeeded", "refId", query.RefID, "frameCount", len(legacyResp.Frames))
+			return legacyResp
+		}
+
+		// Legacy formatter failed, try universal formatter
+		log.DefaultLogger.Debug("Standard formatter returned no data, trying universal formatter", "refId", query.RefID)
+		return formatter.FormatUniversal(results, query)
+
 	case *nrdb.NRDBResultContainerMultiResultCustomized:
+		// Check if RawResponse contains nested facets structure
+		log.DefaultLogger.Debug("Checking RawResponse for nested facets", "refId", query.RefID, "hasRawResponse", r.RawResponse != nil)
+		if r.RawResponse != nil {
+			log.DefaultLogger.Debug("RawResponse keys", "refId", query.RefID, "keys", func() []string {
+				keys := make([]string, 0, len(r.RawResponse))
+				for k := range r.RawResponse {
+					keys = append(keys, k)
+				}
+				return keys
+			}())
+
+			if facets, hasFacets := r.RawResponse["facets"]; hasFacets && facets != nil {
+				log.DefaultLogger.Debug("Detected nested facets in RawResponse, using universal formatter", "refId", query.RefID)
+				return formatter.FormatUniversal(r.RawResponse, query)
+			}
+		}
+
 		log.DefaultLogger.Debug("Using faceted timeseries formatter", "refId", query.RefID)
-		return formatter.FormatFacetedTimeseriesResults(r, query)
+		legacyResp := formatter.FormatFacetedTimeseriesResults(r, query)
+
+		// If legacy formatter succeeded, use it
+		if legacyResp.Error == nil && len(legacyResp.Frames) > 0 {
+			log.DefaultLogger.Debug("Faceted timeseries formatter succeeded", "refId", query.RefID, "frameCount", len(legacyResp.Frames))
+			return legacyResp
+		}
+
+		// Legacy formatter failed, try universal formatter
+		log.DefaultLogger.Debug("Faceted timeseries formatter returned no data, trying universal formatter", "refId", query.RefID)
+		return formatter.FormatUniversal(results, query)
+
 	default:
-		resp.Error = fmt.Errorf("unexpected result type from NRQL query execution")
-		log.DefaultLogger.Error("Unexpected result type", "refId", query.RefID, "type", fmt.Sprintf("%T", results))
-		return resp
+		// Unknown response type - use universal formatter
+		log.DefaultLogger.Debug("Unknown response type, using universal formatter", "refId", query.RefID, "type", fmt.Sprintf("%T", results))
+		return formatter.FormatUniversal(results, query)
 	}
 }

--- a/pkg/handler/query_handler_test.go
+++ b/pkg/handler/query_handler_test.go
@@ -3,7 +3,9 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"newrelic-grafana-plugin/pkg/models"
 	"newrelic-grafana-plugin/pkg/nrdbiface"
@@ -470,4 +472,72 @@ func TestHandleEdgeCases_QueryHandler(t *testing.T) {
 		assert.NotNil(t, response.Error)
 		assert.Contains(t, response.Error.Error(), "query text cannot be empty")
 	})
+}
+
+func TestInjectTimeRange(t *testing.T) {
+	now := time.Now()
+	from := now.Add(-6 * time.Hour)
+	tr := backend.TimeRange{From: from, To: now}
+
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "injects when no SINCE",
+			query:    "SELECT count(*) FROM Transaction",
+			expected: "SELECT count(*) FROM Transaction SINCE " + fmt.Sprintf("%d", from.UnixMilli()) + " UNTIL " + fmt.Sprintf("%d", now.UnixMilli()),
+		},
+		{
+			name:     "skips when SINCE present",
+			query:    "SELECT count(*) FROM Transaction SINCE 1 hour ago",
+			expected: "SELECT count(*) FROM Transaction SINCE 1 hour ago",
+		},
+		{
+			name:     "skips when since lowercase",
+			query:    "SELECT count(*) FROM Transaction since 30 minutes ago",
+			expected: "SELECT count(*) FROM Transaction since 30 minutes ago",
+		},
+		{
+			name:     "skips when COMPARE WITH present",
+			query:    "SELECT count(*) FROM Transaction COMPARE WITH 1 hour ago",
+			expected: "SELECT count(*) FROM Transaction COMPARE WITH 1 hour ago",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := injectTimeRange(tt.query, tr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsLogQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected bool
+	}{
+		{"basic FROM Log", "SELECT * FROM Log", true},
+		{"lowercase from log", "select * from log", true},
+		{"mixed case", "Select * From Log", true},
+		{"with WHERE", "SELECT * FROM Log WHERE level = 'ERROR'", true},
+		{"with FACET", "SELECT message FROM Log FACET hostname", true},
+		{"with TIMESERIES", "SELECT count(*) FROM Log TIMESERIES", true},
+		{"FROM LogMessage should not match", "SELECT * FROM LogMessage", false},
+		{"FROM TransactionLog should not match", "SELECT * FROM TransactionLog", false},
+		{"FROM Transaction", "SELECT * FROM Transaction", false},
+		{"FROM Transaction with log in WHERE", "SELECT * FROM Transaction WHERE message LIKE '%log%'", false},
+		{"multi-event FROM Log, Transaction", "SELECT * FROM Log, Transaction", true},
+		{"empty query", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsLogQuery(tt.query)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,17 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { Button, Switch, ButtonGroup, Icon, Tooltip } from '@grafana/ui';
+import { Button, Switch, ButtonGroup, Icon, Tooltip, CodeEditor } from '@grafana/ui';
 import { DataSource } from '../datasource';
 import { NewRelicQuery, NewRelicDataSourceOptions } from '../types';
 import { NRQLQueryBuilder } from './query/NRQLQueryBuilder';
 import { validateNrqlQuery } from '../utils/validation';
 import { logger } from '../utils/logger';
 import { buildNRQLWithTimeIntegration, hasGrafanaTimeVariables, GRAFANA_TIME_VARIABLES } from '../utils/timeUtils';
-import * as monaco from 'monaco-editor';
-import { loader } from '@monaco-editor/react';
-
-loader.config({ monaco });
-import { Editor } from '@monaco-editor/react';
+import { registerNrqlCompletionProvider } from '../utils/nrqlCompletions';
 type Props = QueryEditorProps<DataSource, NewRelicQuery, NewRelicDataSourceOptions>;
 
 /**
@@ -26,21 +22,18 @@ export function QueryEditor({ query, onChange, onRunQuery, range }: Props) {
   );
 
   //On Editor Change Callback function
-  function handleEditorChange(queryString: any, event: any) {
+  function handleEditorChange(queryString: string) {
     handleNRQLChange(queryString);
   }
 
-   //On Editor did mount life cycle hook function
+  //On Editor did mount life cycle hook function
   function handleEditorDidMount(editor: any, monaco: any) {
-    
-  }
- //On Editor will mount hook function
-  function handleEditorWillMount(monaco: any) {
-  }
-
-  //On Editor Validation Callback function
-  function handleEditorValidation(markers: any) {
-   
+    // Sync editor content with query text on mount — getDefaultQuery() may
+    // populate query.queryText after the initial rawNRQL state is set to ''.
+    if (query.queryText && editor.getValue() !== query.queryText) {
+      editor.setValue(query.queryText);
+      setRawNRQL(query.queryText);
+    }
   }
   // Local state for the raw NRQL text
   const [rawNRQL, setRawNRQL] = useState(query.queryText || '');
@@ -78,6 +71,18 @@ export function QueryEditor({ query, onChange, onRunQuery, range }: Props) {
       return false;
     }
   }, [query.refId]);
+
+  // Populate default query on mount if editor is empty
+  useEffect(() => {
+    if (!query.queryText || query.queryText.trim() === '') {
+      const defaultQuery = useGrafanaTime
+        ? 'SELECT count(*) FROM Transaction SINCE $__from UNTIL $__to'
+        : 'SELECT count(*) FROM Transaction SINCE 1 hour ago';
+      setRawNRQL(defaultQuery);
+      onChange({ ...query, queryText: defaultQuery, useGrafanaTime });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Update rawNRQL when query changes externally (but don't validate)
   useEffect(() => {
@@ -319,18 +324,16 @@ export function QueryEditor({ query, onChange, onRunQuery, range }: Props) {
       ) : (
         <div role="region" aria-label="NRQL Text Editor">
 
-          <Editor
-            height="10vh"
-            theme='vs-dark'
-            options={{ minimap: { enabled: false } }}
-            defaultLanguage="sql"
-            defaultValue="-- Write your SQL here"
-            onChange={handleEditorChange}
-            onMount={handleEditorDidMount}
-            beforeMount={handleEditorWillMount}
-            onValidate={handleEditorValidation}
+          <CodeEditor
+            height="150px"
+            language="sql"
             value={rawNRQL}
-            data-testid="nrql-textarea"
+            onBlur={handleEditorChange}
+            onChange={handleEditorChange}
+            onBeforeEditorMount={(monaco) => registerNrqlCompletionProvider(monaco)}
+            onEditorDidMount={handleEditorDidMount}
+            showMiniMap={false}
+            monacoOptions={{ wordWrap: 'on' }}
           />
          
 

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { CodeEditor } from '@grafana/ui';
+import { registerNrqlCompletionProvider } from '../utils/nrqlCompletions';
+
+interface VariableQueryEditorProps {
+  query: string;
+  onChange: (query: string, definition: string) => void;
+}
+
+/**
+ * Custom variable query editor with NRQL intellisense.
+ * Replaces Grafana's default plain text input for "Query" type variables.
+ */
+export const VariableQueryEditor = ({ query, onChange }: VariableQueryEditorProps) => {
+  return (
+    <CodeEditor
+      height="100px"
+      language="sql"
+      value={query}
+      onBlur={(value) => onChange(value, value)}
+      onBeforeEditorMount={(monaco) => registerNrqlCompletionProvider(monaco)}
+      showMiniMap={false}
+      monacoOptions={{ wordWrap: 'on' }}
+    />
+  );
+};

--- a/src/components/__tests__/QueryEditor.test.tsx
+++ b/src/components/__tests__/QueryEditor.test.tsx
@@ -1,19 +1,20 @@
-
-// IMPORTANT: This single, comprehensive mock must be at the very top
-jest.mock('@monaco-editor/react', () => ({
-  __esModule: true,
-  loader: {
-    config: jest.fn(),
-  },
-  Editor: (props: any) => {
-    return (
+// Mock @grafana/ui — keep real components, override CodeEditor with a testable textarea
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    CodeEditor: (props: any) => (
       <textarea
-        data-testid={props['data-testid'] || 'nrql-textarea'}
+        data-testid="nrql-textarea"
         value={props.value}
-        onChange={e => props.onChange && props.onChange(e.target.value, e)}
+        onChange={e => props.onChange && props.onChange(e.target.value)}
       />
-    );
-  },
+    ),
+  };
+});
+
+jest.mock('../../utils/nrqlCompletions', () => ({
+  registerNrqlCompletionProvider: jest.fn(),
 }));
 
 import React from 'react';

--- a/src/components/__tests__/VariableQueryEditor.test.tsx
+++ b/src/components/__tests__/VariableQueryEditor.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { VariableQueryEditor } from '../VariableQueryEditor';
+import { registerNrqlCompletionProvider } from '../../utils/nrqlCompletions';
+
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    CodeEditor: (props: any) => {
+      // Simulate onBeforeEditorMount being called
+      if (props.onBeforeEditorMount) {
+        props.onBeforeEditorMount({ languages: { registerCompletionItemProvider: jest.fn(), CompletionItemKind: {}, CompletionItemInsertTextRule: { InsertAsSnippet: 4 } } });
+      }
+      return (
+        <textarea
+          data-testid="variable-query-editor"
+          value={props.value}
+          onChange={(e) => props.onBlur && props.onBlur(e.target.value)}
+        />
+      );
+    },
+  };
+});
+
+jest.mock('../../utils/nrqlCompletions', () => ({
+  registerNrqlCompletionProvider: jest.fn(),
+}));
+
+describe('VariableQueryEditor', () => {
+  it('renders CodeEditor with correct value', () => {
+    render(
+      <VariableQueryEditor
+        query="SELECT uniques(appName) FROM Transaction"
+        onChange={jest.fn()}
+      />
+    );
+
+    const editor = screen.getByTestId('variable-query-editor');
+    expect(editor).toBeInTheDocument();
+    expect(editor).toHaveValue('SELECT uniques(appName) FROM Transaction');
+  });
+
+  it('calls onChange on blur', () => {
+    const onChange = jest.fn();
+    render(
+      <VariableQueryEditor
+        query="SELECT uniques(appName) FROM Transaction"
+        onChange={onChange}
+      />
+    );
+
+    const editor = screen.getByTestId('variable-query-editor');
+    editor.focus();
+    // Simulate change which triggers onBlur in our mock
+    const event = { target: { value: 'SELECT count(*) FROM Log' } };
+    editor.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+  it('registers NRQL completion provider on mount', () => {
+    render(
+      <VariableQueryEditor
+        query=""
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(registerNrqlCompletionProvider).toHaveBeenCalled();
+  });
+
+  it('renders with empty query', () => {
+    render(
+      <VariableQueryEditor
+        query=""
+        onChange={jest.fn()}
+      />
+    );
+
+    const editor = screen.getByTestId('variable-query-editor');
+    expect(editor).toHaveValue('');
+  });
+});

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,14 @@
-import { DataSourceInstanceSettings, CoreApp, ScopedVars } from '@grafana/data';
+import {
+  DataSourceInstanceSettings,
+  CoreApp,
+  ScopedVars,
+  MetricFindValue,
+  FieldType,
+  SupplementaryQueryType,
+  SupplementaryQueryOptions,
+} from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
 
 import { NewRelicQuery, NewRelicDataSourceOptions } from './types';
 import { validateNrqlQuery } from './utils/validation';
@@ -33,6 +42,83 @@ export class DataSource extends DataSourceWithBackend<NewRelicQuery, NewRelicDat
       queryText: defaultQuery,
       refId: 'A',
     };
+  }
+
+  /**
+   * Executes a NRQL query and returns results for Grafana dashboard variables.
+   * Called by Grafana when a "Query" type variable runs its query.
+   */
+  async metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {
+    if (!query || query.trim().length === 0) {
+      return [];
+    }
+
+    const request = {
+      targets: [
+        {
+          refId: 'variable',
+          queryText: query,
+          useGrafanaTime: false,
+        } as NewRelicQuery,
+      ],
+      range: options?.range,
+      requestId: 'variable-query',
+      interval: '1m',
+      intervalMs: 60000,
+      scopedVars: options?.scopedVars || {},
+      timezone: 'UTC',
+      app: 'dashboard',
+      startTime: Date.now(),
+    } as any;
+
+    try {
+      const response = await lastValueFrom(super.query(request));
+
+      if (!response?.data?.length) {
+        return [];
+      }
+
+      const values: MetricFindValue[] = [];
+
+      for (const frame of response.data) {
+        if (!frame.fields?.length) {
+          continue;
+        }
+
+        // Skip time/number fields — find string/data fields for variable values
+        for (const field of frame.fields) {
+          if (field.type === FieldType.time) {
+            continue;
+          }
+
+          const fieldValues = field.values?.toArray?.() ?? Array.from(field.values ?? []);
+
+          for (const val of fieldValues) {
+            if (val == null) {
+              continue;
+            }
+            const strVal = String(val);
+            // Expand comma-separated uniques() results
+            if (fieldValues.length === 1 && typeof val === 'string' && val.includes(', ')) {
+              const parts = val.split(', ').map((v: string) => v.trim()).filter(Boolean);
+              for (const part of parts) {
+                values.push({ text: part, value: part });
+              }
+            } else {
+              values.push({ text: strVal, value: strVal });
+            }
+          }
+
+          // Use the first non-time field only
+          break;
+        }
+      }
+
+      return values;
+    } catch (error) {
+      logger.error('Variable query failed', error as Error);
+      return [];
+    }
   }
 
   /**
@@ -106,6 +192,57 @@ export class DataSource extends DataSourceWithBackend<NewRelicQuery, NewRelicDat
       return false;
     }
   }
+
+  // ── Logs support ──────────────────────────────────────────────────
+
+  /** Regex matching "FROM Log" as a standalone event type (not "FROM LogMessage") */
+  private static LOG_QUERY_REGEX = /\bFROM\s+Log\b/i;
+
+  /**
+   * Checks if the NRQL query targets the Log event type.
+   */
+  private isLogQuery(query: string): boolean {
+    return DataSource.LOG_QUERY_REGEX.test(query);
+  }
+
+  /**
+   * Returns the supplementary query types this datasource supports.
+   * Enables the log volume histogram in Grafana Explore.
+   */
+  getSupportedSupplementaryQueryTypes(): SupplementaryQueryType[] {
+    return [SupplementaryQueryType.LogsVolume];
+  }
+
+  /**
+   * Generates a supplementary query for log volume histograms.
+   * Preserves WHERE filters from the original log query.
+   */
+  getSupplementaryQuery(
+    options: SupplementaryQueryOptions,
+    originalQuery: NewRelicQuery
+  ): NewRelicQuery | undefined {
+    if (options.type !== SupplementaryQueryType.LogsVolume) {
+      return undefined;
+    }
+
+    if (!originalQuery.queryText || !this.isLogQuery(originalQuery.queryText)) {
+      return undefined;
+    }
+
+    // Extract WHERE clause from the original query, preserving user's filters
+    const whereMatch = originalQuery.queryText.match(
+      /\bWHERE\b(.+?)(?=\s*\b(?:SINCE|UNTIL|LIMIT|TIMESERIES|FACET|ORDER\s+BY|COMPARE\s+WITH)\b|$)/i
+    );
+    const whereClause = whereMatch ? ` WHERE${whereMatch[1]}` : '';
+
+    return {
+      ...originalQuery,
+      refId: `${originalQuery.refId}-logs-volume`,
+      queryText: `SELECT count(*) FROM Log${whereClause} TIMESERIES`,
+    };
+  }
+
+  // ── Connection test ──────────────────────────────────────────────
 
   /**
    * Tests the data source connection

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,8 +2,10 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
+import { VariableQueryEditor } from './components/VariableQueryEditor';
 import { NewRelicQuery, NewRelicDataSourceOptions } from './types';
 
 export const plugin = new DataSourcePlugin<DataSource, NewRelicQuery, NewRelicDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,6 +4,8 @@
   "name": "New Relic",
   "id": "nrgrafanaplugin-newrelic-datasource",
   "metrics": true,
+  "logs": true,
+  "alerting": true,
   "backend": true,
   "executable": "gpx_nrgrafanaplugin_newrelic_datasource",
   "info": {

--- a/src/utils/__tests__/nrqlCompletions.test.ts
+++ b/src/utils/__tests__/nrqlCompletions.test.ts
@@ -1,0 +1,340 @@
+import { getContextFromLine, registerNrqlCompletionProvider, _resetRegistration } from '../nrqlCompletions';
+
+// Helper to build a mock Monaco instance and extract the registered provider
+function createMockMonaco() {
+  const registerFn = jest.fn();
+  const mockMonaco = {
+    languages: {
+      registerCompletionItemProvider: registerFn,
+      CompletionItemKind: {
+        Function: 1,
+        Class: 5,
+        Field: 4,
+        Keyword: 17,
+        Unit: 12,
+        Variable: 6,
+        Value: 11,
+        Constant: 14,
+      },
+      CompletionItemInsertTextRule: {
+        InsertAsSnippet: 4,
+      },
+    },
+  };
+  return { mockMonaco, registerFn };
+}
+
+function getProvider(registerFn: jest.Mock) {
+  return registerFn.mock.calls[0][1];
+}
+
+function getSuggestions(provider: any, lineText: string, column?: number) {
+  const col = column ?? lineText.length + 1;
+  const model = {
+    getLineContent: () => lineText,
+    getWordUntilPosition: () => ({ startColumn: col, endColumn: col }),
+  };
+  const position = { lineNumber: 1, column: col };
+  return provider.provideCompletionItems(model, position).suggestions;
+}
+
+describe('getContextFromLine', () => {
+  it('returns "select" after SELECT keyword', () => {
+    expect(getContextFromLine('SELECT ')).toBe('select');
+  });
+
+  it('returns "select" after comma in SELECT clause', () => {
+    expect(getContextFromLine('SELECT count(*), ')).toBe('select');
+  });
+
+  it('returns "from" after FROM keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM ')).toBe('from');
+  });
+
+  it('returns "where" after WHERE keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction WHERE ')).toBe('where');
+  });
+
+  it('returns "where" after AND keyword', () => {
+    expect(getContextFromLine("SELECT count(*) FROM Transaction WHERE appName = 'test' AND ")).toBe('where');
+  });
+
+  it('returns "where" after OR keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction WHERE x = 1 OR ')).toBe('where');
+  });
+
+  it('returns "facet" after FACET keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction FACET ')).toBe('facet');
+  });
+
+  it('returns "since" after SINCE keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction SINCE ')).toBe('since');
+  });
+
+  it('returns "since" after UNTIL keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction SINCE 1 hour ago UNTIL ')).toBe('since');
+  });
+
+  it('returns "limit" after LIMIT keyword', () => {
+    expect(getContextFromLine('SELECT count(*) FROM Transaction LIMIT ')).toBe('limit');
+  });
+
+  it('returns "join" after JOIN( keyword', () => {
+    expect(getContextFromLine('FROM Transaction JOIN (')).toBe('join');
+  });
+
+  it('returns "join" after INNER JOIN( keyword', () => {
+    expect(getContextFromLine('FROM Transaction INNER JOIN (')).toBe('join');
+  });
+
+  it('returns "join" after LEFT JOIN( keyword', () => {
+    expect(getContextFromLine('FROM Transaction LEFT JOIN (')).toBe('join');
+  });
+
+  it('returns "default" for empty string', () => {
+    expect(getContextFromLine('')).toBe('default');
+  });
+
+  it('returns "default" for partial keyword typing', () => {
+    expect(getContextFromLine('SEL')).toBe('default');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getContextFromLine('select ')).toBe('select');
+    expect(getContextFromLine('from ')).toBe('from');
+    expect(getContextFromLine('Select count(*) From ')).toBe('from');
+  });
+});
+
+describe('registerNrqlCompletionProvider', () => {
+  beforeEach(() => {
+    _resetRegistration();
+  });
+
+  it('registers a completion provider on the sql language', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+
+    expect(registerFn).toHaveBeenCalledTimes(1);
+    expect(registerFn).toHaveBeenCalledWith('sql', expect.objectContaining({
+      triggerCharacters: [' ', ',', '$', '('],
+      provideCompletionItems: expect.any(Function),
+    }));
+  });
+
+  it('only registers once on the same Monaco instance', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    registerNrqlCompletionProvider(mockMonaco);
+
+    expect(registerFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers on each different Monaco instance (Dashboard vs Explore)', () => {
+    const monaco1 = createMockMonaco();
+    const monaco2 = createMockMonaco();
+
+    registerNrqlCompletionProvider(monaco1.mockMonaco);
+    registerNrqlCompletionProvider(monaco2.mockMonaco);
+
+    expect(monaco1.registerFn).toHaveBeenCalledTimes(1);
+    expect(monaco2.registerFn).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Default context ──
+
+  it('returns keyword suggestions for default context', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, '');
+
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions[0].label).toBe('SELECT');
+    const labels = suggestions.map((s: any) => s.label);
+    expect(labels).toContain('FROM');
+    expect(labels).toContain('WHERE');
+    expect(labels).toContain('FACET');
+    expect(labels).toContain('JOIN');
+    expect(labels).toContain('INNER JOIN');
+    expect(labels).toContain('LEFT JOIN');
+    expect(labels).toContain('SLIDE BY');
+    expect(labels).toContain('PREDICT');
+    expect(labels).toContain('SHOW EVENT TYPES');
+    expect(labels).toContain('FACET CASES');
+    expect(labels).toContain('RLIKE');
+    expect(labels).toContain('OFFSET');
+  });
+
+  // ── SELECT context ──
+
+  it('returns aggregator functions first after SELECT', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT ');
+
+    // First real function should be count
+    const fnSuggestions = suggestions.filter((s: any) => s.kind === 1);
+    expect(fnSuggestions[0].label).toBe('count');
+    expect(fnSuggestions[0].insertText).toBe('count(${1:*})');
+  });
+
+  it('includes non-aggregator functions after SELECT', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('capture');
+    expect(labels).toContain('aparse');
+    expect(labels).toContain('if');
+    expect(labels).toContain('numeric');
+    expect(labels).toContain('concat');
+    expect(labels).toContain('abs');
+    expect(labels).toContain('lower');
+    expect(labels).toContain('toDatetime');
+    expect(labels).toContain('convert');
+    expect(labels).toContain('jparse');
+  });
+
+  it('includes new aggregator functions (median, derivative, cdfPercentage, etc.)', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('median');
+    expect(labels).toContain('derivative');
+    expect(labels).toContain('cdfPercentage');
+    expect(labels).toContain('getCdfCount');
+    expect(labels).toContain('keyset');
+    expect(labels).toContain('percentage');
+    expect(labels).toContain('buckets');
+    expect(labels).toContain('accountId');
+    expect(labels).toContain('eventType');
+  });
+
+  it('includes * wildcard in SELECT suggestions', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('*');
+  });
+
+  // ── FROM context ──
+
+  it('returns all event types after FROM', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT count(*) FROM ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels[0]).toBe('Transaction');
+    // New event types
+    expect(labels).toContain('JavaScriptError');
+    expect(labels).toContain('AjaxRequest');
+    expect(labels).toContain('MobileRequest');
+    expect(labels).toContain('K8sContainerSample');
+    expect(labels).toContain('K8sPodSample');
+    expect(labels).toContain('K8sNodeSample');
+    expect(labels).toContain('SyntheticRequest');
+    expect(labels).toContain('AwsLambdaInvocation');
+    expect(labels).toContain('NrIntegrationError');
+    expect(labels).toContain('StorageSample');
+  });
+
+  // ── WHERE context ──
+
+  it('returns fields and non-aggregator functions after WHERE', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT count(*) FROM Transaction WHERE ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    // Fields
+    expect(labels).toContain('appName');
+    expect(labels).toContain('service.name');
+    expect(labels).toContain('entity.name');
+    expect(labels).toContain('traceId');
+    expect(labels).toContain('spanId');
+    expect(labels).toContain('error.message');
+    expect(labels).toContain('cpuPercent');
+    expect(labels).toContain('clusterName');
+    expect(labels).toContain('podName');
+    expect(labels).toContain('pageUrl');
+    expect(labels).toContain('city');
+    // Non-aggregator functions are also valid in WHERE
+    expect(labels).toContain('capture');
+    expect(labels).toContain('numeric');
+    expect(labels).toContain('if');
+  });
+
+  // ── FACET context ──
+
+  it('returns fields and functions after FACET', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT count(*) FROM Transaction FACET ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('appName');
+    expect(labels).toContain('capture');
+    expect(labels).toContain('aparse');
+  });
+
+  // ── SINCE context ──
+
+  it('returns full time expressions after SINCE', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT count(*) FROM Transaction SINCE ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('1 hour ago');
+    expect(labels).toContain('1 day ago');
+    expect(labels).toContain('1 week ago');
+    expect(labels).toContain('today');
+    expect(labels).toContain('yesterday');
+    expect(labels).toContain('$__from');
+    expect(labels).toContain('$__to');
+    expect(labels).toContain('$__interval');
+  });
+
+  // ── LIMIT context ──
+
+  it('returns limit values including 5000 and MAX', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'SELECT count(*) FROM Transaction LIMIT ');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels).toContain('10');
+    expect(labels).toContain('5000');
+    expect(labels).toContain('MAX');
+  });
+
+  // ── JOIN context ──
+
+  it('returns FROM and event types after JOIN(', () => {
+    const { mockMonaco, registerFn } = createMockMonaco();
+    registerNrqlCompletionProvider(mockMonaco);
+    const provider = getProvider(registerFn);
+    const suggestions = getSuggestions(provider, 'FROM Transaction JOIN (');
+    const labels = suggestions.map((s: any) => s.label);
+
+    expect(labels[0]).toBe('FROM');
+    expect(labels).toContain('Transaction');
+    expect(labels).toContain('Span');
+  });
+});

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -16,37 +16,37 @@ describe('Validation Utils', () => {
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT * FROM Span').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT average(duration) FROM Transaction').isValid).toBe(true);
-      
+
       // Queries with WHERE clause
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction WHERE appName = "MyApp"').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction WHERE duration > 100').isValid).toBe(true);
-      
+
       // Queries with FACET clause
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction FACET appName').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction FACET appName, host').isValid).toBe(true);
-      
+
       // Queries with time clauses
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction SINCE 1 hour ago').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction SINCE 1 hour ago UNTIL 30 minutes ago').isValid).toBe(true);
-      
+
       // Queries with TIMESERIES
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction TIMESERIES').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction TIMESERIES AUTO').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction TIMESERIES 5 minutes').isValid).toBe(true);
-      
+
       // Queries with LIMIT
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction LIMIT 100').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction LIMIT 1000').isValid).toBe(true);
-      
+
       // Complex queries
       const complexQuery = 'SELECT average(duration) FROM Transaction WHERE appName = "MyApp" FACET host SINCE 1 hour ago TIMESERIES AUTO LIMIT 100';
       expect(validateNrqlQuery(complexQuery).isValid).toBe(true);
-      
+
       // Case insensitive
       expect(validateNrqlQuery('select count(*) from Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT COUNT(*) FROM TRANSACTION').isValid).toBe(true);
       expect(validateNrqlQuery('Select Average(duration) From Transaction').isValid).toBe(true);
-      
+
       // Aggregation functions
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT average(duration) FROM Transaction').isValid).toBe(true);
@@ -56,11 +56,11 @@ describe('Validation Utils', () => {
       expect(validateNrqlQuery('SELECT percentile(duration, 95) FROM Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT uniqueCount(userId) FROM Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT latest(timestamp) FROM Transaction').isValid).toBe(true);
-      
+
       // Multiple attributes
       expect(validateNrqlQuery('SELECT duration, responseTime FROM Transaction').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT appName, host, duration FROM Transaction').isValid).toBe(true);
-      
+
       // Special characters
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction WHERE appName = "My-App_2023"').isValid).toBe(true);
       expect(validateNrqlQuery('SELECT count(*) FROM Transaction WHERE host LIKE "%prod%"').isValid).toBe(true);
@@ -473,7 +473,7 @@ describe('Validation Utils', () => {
         [],
         true,
         false,
-        function() {},
+        function () { },
       ];
 
       invalidInputs.forEach(input => {

--- a/src/utils/nrqlCompletions.ts
+++ b/src/utils/nrqlCompletions.ts
@@ -1,0 +1,439 @@
+/**
+ * NRQL context-aware autocomplete provider for Monaco editor.
+ * Registers a CompletionItemProvider on the 'sql' language that suggests
+ * keywords, functions, event types, fields, and time expressions based
+ * on the NRQL clause the cursor is currently in.
+ *
+ * Coverage based on the full NRQL reference:
+ * https://docs.newrelic.com/docs/nrql/nrql-syntax-clauses-functions
+ */
+
+// ── Completion data ──────────────────────────────────────────────────
+
+const NRQL_KEYWORDS = [
+  // Required clauses
+  'SELECT', 'FROM',
+  // Filtering & logic
+  'WHERE', 'AND', 'OR', 'NOT', 'IN', 'NOT IN', 'LIKE', 'NOT LIKE',
+  'RLIKE', 'NOT RLIKE', 'IS', 'IS NOT', 'NULL',
+  // Grouping & ordering
+  'FACET', 'FACET CASES', 'LIMIT', 'OFFSET', 'ORDER BY', 'ASC', 'DESC',
+  // Time
+  'SINCE', 'UNTIL', 'TIMESERIES', 'AUTO', 'COMPARE WITH', 'SLIDE BY',
+  'WITH TIMEZONE',
+  // Labeling & variables
+  'AS', 'WITH', 'WITH ... AS',
+  // Joins
+  'JOIN', 'INNER JOIN', 'LEFT JOIN', 'ON',
+  // Metric format
+  'WITH METRIC_FORMAT',
+  // Other
+  'EXTRAPOLATE', 'SHOW EVENT TYPES', 'PREDICT',
+];
+
+/** Aggregator functions — used after SELECT */
+const NRQL_AGGREGATOR_FUNCTIONS = [
+  // Counting
+  { label: 'count', insert: 'count(${1:*})', detail: 'Count of events' },
+  { label: 'uniqueCount', insert: 'uniqueCount(${1:attribute})', detail: 'Count of unique values' },
+  // Math aggregations
+  { label: 'sum', insert: 'sum(${1:attribute})', detail: 'Sum of a numeric attribute' },
+  { label: 'average', insert: 'average(${1:attribute})', detail: 'Average of a numeric attribute' },
+  { label: 'median', insert: 'median(${1:attribute})', detail: 'Median value (50th percentile)' },
+  { label: 'min', insert: 'min(${1:attribute})', detail: 'Minimum value' },
+  { label: 'max', insert: 'max(${1:attribute})', detail: 'Maximum value' },
+  { label: 'stddev', insert: 'stddev(${1:attribute})', detail: 'Standard deviation' },
+  { label: 'percentile', insert: 'percentile(${1:attribute}, ${2:95})', detail: 'Percentile of an attribute' },
+  // Rate & derivative
+  { label: 'rate', insert: 'rate(${1:sum(attribute)}, ${2:1 minute})', detail: 'Rate of change over time' },
+  { label: 'derivative', insert: 'derivative(${1:attribute}, ${2:1 minute})', detail: 'Rate of change (derivative)' },
+  // Selection
+  { label: 'latest', insert: 'latest(${1:attribute})', detail: 'Most recent value' },
+  { label: 'earliest', insert: 'earliest(${1:attribute})', detail: 'Oldest value' },
+  { label: 'uniques', insert: 'uniques(${1:attribute})', detail: 'List of unique values' },
+  // Distribution
+  { label: 'histogram', insert: 'histogram(${1:attribute}, ${2:10}, ${3:20})', detail: 'Histogram buckets' },
+  { label: 'cdfPercentage', insert: 'cdfPercentage(${1:attribute}, ${2:threshold})', detail: 'Cumulative distribution percentage' },
+  { label: 'getCdfCount', insert: 'getCdfCount(${1:attribute}, ${2:threshold})', detail: 'Cumulative distribution count' },
+  { label: 'percentage', insert: 'percentage(${1:count(*)}, WHERE ${2:condition})', detail: 'Percentage matching a condition' },
+  // Performance
+  { label: 'apdex', insert: 'apdex(${1:attribute}, ${2:0.5})', detail: 'Apdex score' },
+  { label: 'funnel', insert: 'funnel(${1:attribute}, WHERE ${2:step1} AS ${3:\'Step 1\'}, WHERE ${4:step2} AS ${5:\'Step 2\'})', detail: 'Funnel analysis' },
+  // Filtered aggregation
+  { label: 'filter', insert: 'filter(${1:count(*)}, WHERE ${2:condition})', detail: 'Filtered aggregation' },
+  // Metadata
+  { label: 'keyset', insert: 'keyset()', detail: 'List of attributes on an event type' },
+  { label: 'eventType', insert: 'eventType()', detail: 'Returns the event type' },
+  { label: 'accountId', insert: 'accountId()', detail: 'Returns the account ID' },
+  // Bucketing (used with FACET)
+  { label: 'buckets', insert: 'buckets(${1:attribute}, ${2:ceiling}, ${3:count})', detail: 'Segment data into buckets' },
+];
+
+/** Non-aggregator functions — used in SELECT, WHERE, FACET, WITH */
+const NRQL_NON_AGGREGATOR_FUNCTIONS = [
+  // String parsing
+  { label: 'capture', insert: "capture(${1:attribute}, r'${2:pattern}')", detail: 'Extract values via regex' },
+  { label: 'aparse', insert: "aparse(${1:attribute}, '${2:pattern}')", detail: 'Anchor parse — extract values from strings' },
+  { label: 'concat', insert: "concat(${1:value1}, ${2:value2})", detail: 'Concatenate values into a string' },
+  // Type conversion
+  { label: 'numeric', insert: 'numeric(${1:value})', detail: 'Convert string to number' },
+  { label: 'string', insert: 'string(${1:value})', detail: 'Convert value to string' },
+  { label: 'boolean', insert: 'boolean(${1:value})', detail: 'Convert value to boolean' },
+  // Conditional
+  { label: 'if', insert: 'if(${1:condition}, ${2:trueVal}, ${3:falseVal})', detail: 'Conditional expression' },
+  // String manipulation
+  { label: 'length', insert: 'length(${1:attribute})', detail: 'String length' },
+  { label: 'lower', insert: 'lower(${1:attribute})', detail: 'Convert to lowercase' },
+  { label: 'upper', insert: 'upper(${1:attribute})', detail: 'Convert to uppercase' },
+  { label: 'position', insert: 'position(${1:attribute}, ${2:substring})', detail: 'Find substring position' },
+  { label: 'substring', insert: 'substring(${1:attribute}, ${2:start}, ${3:length})', detail: 'Extract substring' },
+  // Math
+  { label: 'abs', insert: 'abs(${1:value})', detail: 'Absolute value' },
+  { label: 'ceil', insert: 'ceil(${1:value})', detail: 'Round up to nearest integer' },
+  { label: 'floor', insert: 'floor(${1:value})', detail: 'Round down to nearest integer' },
+  { label: 'round', insert: 'round(${1:value})', detail: 'Round to nearest integer' },
+  { label: 'pow', insert: 'pow(${1:base}, ${2:exponent})', detail: 'Raise to a power' },
+  { label: 'sqrt', insert: 'sqrt(${1:value})', detail: 'Square root' },
+  { label: 'exp', insert: 'exp(${1:value})', detail: 'e raised to value' },
+  { label: 'ln', insert: 'ln(${1:value})', detail: 'Natural logarithm' },
+  { label: 'log', insert: 'log(${1:value})', detail: 'Logarithm (base 10)' },
+  { label: 'log2', insert: 'log2(${1:value})', detail: 'Logarithm (base 2)' },
+  { label: 'log10', insert: 'log10(${1:value})', detail: 'Logarithm (base 10)' },
+  { label: 'mod', insert: 'mod(${1:value}, ${2:divisor})', detail: 'Modulo (remainder)' },
+  { label: 'clamp_max', insert: 'clamp_max(${1:value}, ${2:max})', detail: 'Clamp value to maximum' },
+  { label: 'clamp_min', insert: 'clamp_min(${1:value}, ${2:min})', detail: 'Clamp value to minimum' },
+  // Date/time
+  { label: 'toDatetime', insert: 'toDatetime(${1:timestamp})', detail: 'Convert epoch to datetime' },
+  { label: 'dateOf', insert: 'dateOf(${1:timestamp})', detail: 'Date part of timestamp' },
+  { label: 'monthOf', insert: 'monthOf(${1:timestamp})', detail: 'Month from timestamp' },
+  { label: 'yearOf', insert: 'yearOf(${1:timestamp})', detail: 'Year from timestamp' },
+  { label: 'dayOfMonthOf', insert: 'dayOfMonthOf(${1:timestamp})', detail: 'Day of month from timestamp' },
+  { label: 'hourOf', insert: 'hourOf(${1:timestamp})', detail: 'Hour from timestamp' },
+  { label: 'minuteOf', insert: 'minuteOf(${1:timestamp})', detail: 'Minute from timestamp' },
+  { label: 'weekdayOf', insert: 'weekdayOf(${1:timestamp})', detail: 'Weekday from timestamp' },
+  { label: 'weekOf', insert: 'weekOf(${1:timestamp})', detail: 'Week number from timestamp' },
+  // Unit conversion
+  { label: 'convert', insert: "convert(${1:attribute}, '${2:fromUnit}', '${3:toUnit}')", detail: 'Convert between units' },
+  // Encoding & blobs
+  { label: 'blob', insert: 'blob(${1:attribute})', detail: 'Base-64 encoded blob' },
+  { label: 'decode', insert: 'decode(${1:attribute})', detail: 'Decode base-64 blob' },
+  { label: 'encode', insert: 'encode(${1:attribute})', detail: 'Encode to base-64' },
+  // Data lookup
+  { label: 'lookup', insert: 'lookup(${1:tableName}, ${2:key})', detail: 'Lookup table query' },
+  { label: 'mapKeys', insert: 'mapKeys(${1:attribute})', detail: 'Keys from a map attribute' },
+  { label: 'mapValues', insert: 'mapValues(${1:attribute})', detail: 'Values from a map attribute' },
+  { label: 'jparse', insert: "jparse(${1:attribute}, '${2:path}')", detail: 'Parse JSON attribute' },
+];
+
+const NRQL_EVENT_TYPES = [
+  // APM
+  'Transaction', 'TransactionError', 'Span', 'Metric', 'Error',
+  // Logs
+  'Log',
+  // Browser
+  'PageView', 'PageAction', 'BrowserInteraction', 'JavaScriptError', 'AjaxRequest',
+  // Mobile
+  'Mobile', 'MobileSession', 'MobileCrash', 'MobileRequest', 'MobileHandledException', 'MobileRequestError',
+  // Infrastructure
+  'SystemSample', 'ProcessSample', 'NetworkSample', 'StorageSample',
+  'ContainerSample', 'InfrastructureEvent',
+  // Kubernetes
+  'K8sContainerSample', 'K8sPodSample', 'K8sNodeSample', 'K8sClusterSample',
+  'K8sDeploymentSample', 'K8sNamespaceSample', 'K8sDaemonsetSample',
+  // Synthetics
+  'SyntheticCheck', 'SyntheticRequest', 'SyntheticMonitor',
+  // Serverless
+  'AwsLambdaInvocation', 'ServerlessSample',
+  // Platform & audit
+  'NrAuditEvent', 'NrConsumption', 'NrDailyUsage', 'NrdbQuery',
+  'NrIntegrationError', 'Relationship',
+];
+
+const NRQL_FIELDS = [
+  // Common
+  'appName', 'service.name', 'entity.name', 'entityGuid', 'name', 'environment',
+  'host', 'hostname',
+  // Timing
+  'duration', 'responseTime', 'totalTime', 'webDuration',
+  'databaseDuration', 'externalDuration', 'databaseCallCount', 'externalCallCount',
+  // Errors
+  'error', 'error.message', 'error.class', 'errorMessage', 'errorType',
+  // HTTP
+  'httpResponseCode', 'request.uri', 'request.method', 'http.statusCode',
+  // Transaction
+  'transactionType', 'transactionSubType',
+  // Tracing
+  'traceId', 'spanId', 'parentId', 'span.kind', 'sampled', 'priority', 'category',
+  // Timestamps & identity
+  'timestamp', 'message', 'level', 'userId', 'sessionId', 'session',
+  // Browser
+  'pageUrl', 'browserTransactionName', 'userAgentName', 'userAgentOS', 'deviceType',
+  'backendDuration', 'networkDuration', 'connectionSetupDuration',
+  'domProcessingDuration', 'pageRenderingDuration',
+  // Geo
+  'city', 'regionCode', 'countryCode', 'asnLatitude', 'asnLongitude',
+  // Infrastructure
+  'cpuPercent', 'memoryUsedPercent', 'memoryUsedBytes', 'diskUsedPercent',
+  'containerName', 'containerId',
+  // Kubernetes
+  'clusterName', 'namespaceName', 'podName', 'deploymentName', 'nodeName',
+  // Performance
+  'nr.apdexPerfZone',
+];
+
+const NRQL_TIME_EXPRESSIONS = [
+  '1 minute ago', '5 minutes ago', '15 minutes ago', '30 minutes ago',
+  '1 hour ago', '2 hours ago', '6 hours ago', '12 hours ago',
+  '1 day ago', '2 days ago', '1 week ago', '1 month ago',
+  'today', 'yesterday', 'this week', 'this month',
+];
+
+const GRAFANA_VARIABLES = ['$__from', '$__to', '$__interval'];
+
+// ── Context detection ────────────────────────────────────────────────
+
+type NrqlContext = 'select' | 'from' | 'where' | 'facet' | 'since' | 'limit' | 'join' | 'default';
+
+/**
+ * Determines the NRQL clause context from the text before the cursor.
+ * Exported for testing.
+ */
+export function getContextFromLine(lineText: string): NrqlContext {
+  const upper = lineText.toUpperCase();
+
+  // Walk backwards through the keywords that delimit clauses.
+  // Order matters — later clauses take priority when they appear last.
+  const clausePatterns: Array<{ pattern: RegExp; context: NrqlContext }> = [
+    { pattern: /\bLIMIT\s+$/i, context: 'limit' },
+    { pattern: /\b(?:SINCE|UNTIL)\s+$/i, context: 'since' },
+    { pattern: /\bFACET\s+$/i, context: 'facet' },
+    { pattern: /\b(?:WHERE|AND|OR)\s+$/i, context: 'where' },
+    { pattern: /\b(?:INNER\s+JOIN|LEFT\s+JOIN|JOIN)\s*\(\s*$/i, context: 'join' },
+    { pattern: /\bFROM\s+$/i, context: 'from' },
+    // After SELECT or after a comma following SELECT (still in SELECT clause)
+    { pattern: /\bSELECT\s+$/i, context: 'select' },
+    { pattern: /,\s*$/i, context: 'select' },
+  ];
+
+  for (const { pattern, context } of clausePatterns) {
+    if (pattern.test(lineText)) {
+      // For comma context, only treat as 'select' if SELECT preceded it
+      if (context === 'select' && pattern.source === ',\\s*$') {
+        if (upper.includes('SELECT') && !upper.includes('FROM')) {
+          return 'select';
+        }
+        continue;
+      }
+      return context;
+    }
+  }
+
+  return 'default';
+}
+
+// ── Provider registration ────────────────────────────────────────────
+
+/**
+ * Tracks which Monaco instances have already had the NRQL provider registered.
+ * WeakSet allows garbage collection of old instances (e.g., when navigating
+ * between Dashboard and Explore) while preventing duplicate registrations
+ * on the same instance.
+ */
+const registeredInstances = new WeakSet<any>();
+
+/**
+ * Registers the NRQL completion item provider on the 'sql' language.
+ * Safe to call multiple times — registers once per Monaco instance.
+ * Uses WeakSet to handle multiple Monaco instances (Dashboard vs Explore).
+ *
+ * @param monaco  The Monaco namespace (received from onBeforeEditorMount)
+ */
+export function registerNrqlCompletionProvider(monaco: any): void {
+  if (registeredInstances.has(monaco)) {
+    return;
+  }
+  registeredInstances.add(monaco);
+
+  monaco.languages.registerCompletionItemProvider('sql', {
+    triggerCharacters: [' ', ',', '$', '('],
+
+    provideCompletionItems(model: any, position: any) {
+      const lineContent = model.getLineContent(position.lineNumber);
+      const textBeforeCursor = lineContent.substring(0, position.column - 1);
+
+      const word = model.getWordUntilPosition(position);
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+
+      const context = getContextFromLine(textBeforeCursor);
+
+      const Kind = monaco.languages.CompletionItemKind;
+      const SnippetRule = monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet;
+
+      const suggestions: any[] = [];
+
+      switch (context) {
+        case 'select': {
+          // Aggregator functions first, then non-aggregator functions
+          NRQL_AGGREGATOR_FUNCTIONS.forEach((fn, i) => {
+            suggestions.push({
+              label: fn.label,
+              kind: Kind.Function,
+              insertText: fn.insert,
+              insertTextRules: SnippetRule,
+              detail: fn.detail,
+              sortText: 'a' + String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          NRQL_NON_AGGREGATOR_FUNCTIONS.forEach((fn, i) => {
+            suggestions.push({
+              label: fn.label,
+              kind: Kind.Function,
+              insertText: fn.insert,
+              insertTextRules: SnippetRule,
+              detail: fn.detail,
+              sortText: 'b' + String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          // Also suggest * for SELECT *
+          suggestions.push({
+            label: '*',
+            kind: Kind.Constant,
+            insertText: '*',
+            detail: 'All attributes',
+            sortText: 'a000',
+            range,
+          });
+          break;
+        }
+
+        case 'from':
+          NRQL_EVENT_TYPES.forEach((et, i) => {
+            suggestions.push({
+              label: et,
+              kind: Kind.Class,
+              insertText: et,
+              detail: 'Event type',
+              sortText: String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+
+        case 'where':
+        case 'facet':
+          NRQL_FIELDS.forEach((f, i) => {
+            suggestions.push({
+              label: f,
+              kind: Kind.Field,
+              insertText: f,
+              detail: 'Attribute',
+              sortText: 'a' + String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          // Non-aggregator functions are also valid in WHERE/FACET
+          NRQL_NON_AGGREGATOR_FUNCTIONS.forEach((fn, i) => {
+            suggestions.push({
+              label: fn.label,
+              kind: Kind.Function,
+              insertText: fn.insert,
+              insertTextRules: SnippetRule,
+              detail: fn.detail,
+              sortText: 'b' + String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+
+        case 'since':
+          NRQL_TIME_EXPRESSIONS.forEach((t, i) => {
+            suggestions.push({
+              label: t,
+              kind: Kind.Unit,
+              insertText: t,
+              detail: 'Time expression',
+              sortText: String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          GRAFANA_VARIABLES.forEach((v, i) => {
+            suggestions.push({
+              label: v,
+              kind: Kind.Variable,
+              insertText: v,
+              detail: 'Grafana variable',
+              sortText: String(100 + i).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+
+        case 'limit':
+          [10, 50, 100, 500, 1000, 5000, 'MAX'].forEach((n, i) => {
+            suggestions.push({
+              label: String(n),
+              kind: Kind.Value,
+              insertText: String(n),
+              detail: 'Limit value',
+              sortText: String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+
+        case 'join':
+          // After JOIN(, suggest a subquery starting with FROM
+          suggestions.push({
+            label: 'FROM',
+            kind: Kind.Keyword,
+            insertText: 'FROM ',
+            detail: 'Start subquery',
+            sortText: '000',
+            range,
+          });
+          NRQL_EVENT_TYPES.forEach((et, i) => {
+            suggestions.push({
+              label: et,
+              kind: Kind.Class,
+              insertText: et,
+              detail: 'Event type',
+              sortText: String(i + 1).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+
+        default:
+          NRQL_KEYWORDS.forEach((kw, i) => {
+            suggestions.push({
+              label: kw,
+              kind: Kind.Keyword,
+              insertText: kw + ' ',
+              detail: 'NRQL keyword',
+              sortText: String(i).padStart(3, '0'),
+              range,
+            });
+          });
+          break;
+      }
+
+      return { suggestions };
+    },
+  });
+}
+
+/**
+ * No-op for backward compatibility with tests.
+ * WeakSet handles deduplication automatically — each fresh mock Monaco
+ * object in tests is a new reference that won't be in the set.
+ */
+export function _resetRegistration(): void {
+  // No action needed — WeakSet auto-handles new mock objects in tests
+}


### PR DESCRIPTION
## Summary

- **Universal formatter**: Fallback handler for any NR response structure (COMPARE WITH, multi-facet, nested facets)
- **Grafana Logs support**: Proper `log-lines` frames with severity color-coding, expandable labels, log volume histogram in Explore
- **NRQL autocomplete**: 192 context-aware suggestions covering the full NRQL spec (keywords, aggregator/non-aggregator functions, event types, fields, time expressions, Grafana variables)
- **Editor migration**: Replaced `@monaco-editor/react` with Grafana's built-in `CodeEditor` — auto theme matching, no external dependency
- **Intellisense fix**: WeakSet-based registration works across Dashboard, Explore, and Variable editors
- **Variable Query Editor**: Custom CodeEditor with NRQL autocomplete for dashboard template variables
- **Cleanup**: Removed staging API URL overrides, added build artifacts to .gitignore

## Test plan

- [ ] All Go tests pass (`go test ./pkg/...`)
- [ ] All frontend tests pass (227 tests across 12 suites)
- [ ] Dashboard panel: NRQL Editor autocomplete works (type `SEL` → suggests `SELECT`)
- [ ] Explore mode: Autocomplete works, log queries render in Logs panel
- [ ] Dashboard variables: CodeEditor with autocomplete replaces plain text input
- [ ] Log queries (`SELECT * FROM Log`): Colored severity, expandable labels, volume histogram
- [ ] Existing metric queries: No regression (table/graph rendering unchanged)
- [ ] COMPARE WITH queries render current vs previous period correctly