### PR TITLE
fix: EU region auth support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newrelic-grafana-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "newrelic-grafana-plugin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-grafana-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A comprehensive Grafana data source plugin for New Relic with full NRQL support",
   "keywords": [
     "grafana",

--- a/pkg/client/newrelic_client.go
+++ b/pkg/client/newrelic_client.go
@@ -87,13 +87,10 @@ func NewClient(config ClientConfig) (*newrelic.NewRelic, error) {
 
 	// Create the client directly using the variable function to allow for testing
 	nrClient, err := NewrelicNewFunc(cfgOpts...)
-	// print nrClient to debug
-	if nrClient != nil {
-		log.DefaultLogger.Debug("NewRelicClient: New Relic client initialized successfully", "client", nrClient)
-	}
 	if err != nil {
 		return nil, &NewRelicClientError{Msg: "failed to initialize New Relic client", Err: err}
 	}
+	log.DefaultLogger.Debug("NewRelicClient: New Relic client initialized successfully")
 
 	return nrClient, nil
 }

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -603,8 +603,6 @@ func formatFacetedAggregationQuery(results *nrdb.NRDBResultContainer, query back
 
 	// Create separate frames for each facet combination
 	for facetKey, facetInfo := range facetData {
-		// Use facet key as the frame name
-		log.DefaultLogger.Debug("Creating frame with facet key", "facetKey", facetKey)
 		frame := data.NewFrame(facetKey)
 		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetInfo.Results}, query)
 		timeField := data.NewField("time", nil, times)
@@ -1193,8 +1191,6 @@ func formatFacetedTimeseriesQueryMulti(results *nrdb.NRDBResultContainerMultiRes
 	log.DefaultLogger.Debug("Extracted aliases from metadata", "aliases", aliases, "count", len(aliases))
 
 	for facetKey, facetInfo := range facetData {
-		// Use composite facet key as frame name
-		log.DefaultLogger.Debug("Creating frame with name", "name", facetKey)
 		frame := data.NewFrame(facetKey)
 		times := createTimeField(&nrdb.NRDBResultContainer{Results: facetInfo.Results}, query)
 		timeField := data.NewField("time", nil, times)
@@ -1223,8 +1219,6 @@ func formatFacetedTimeseriesQueryMulti(results *nrdb.NRDBResultContainerMultiRes
 			}
 		}
 
-		log.DefaultLogger.Debug("Processing metrics for facet", "facetKey", facetKey, "metricCount", len(metricFieldNames), "metrics", metricFieldNames)
-
 		// Create a field for each metric
 		for _, metricName := range metricFieldNames {
 			values := make([]*float64, len(facetInfo.Results))
@@ -1244,11 +1238,6 @@ func formatFacetedTimeseriesQueryMulti(results *nrdb.NRDBResultContainerMultiRes
 	}
 
 	log.DefaultLogger.Debug("Faceted timeseries - Total frames in response", "frameCount", len(resp.Frames))
-
-	// Log frame names for debugging
-	for i, frame := range resp.Frames {
-		log.DefaultLogger.Debug("Frame name", "index", i, "name", frame.Name)
-	}
 
 	return resp
 }
@@ -1303,8 +1292,6 @@ func groupTimeseriesByAllFacetsMulti(results *nrdb.NRDBResultContainerMultiResul
 			}
 		}
 
-		log.DefaultLogger.Debug("Grouping by composite facet", "facetKey", facetKey, "labels", labels)
-
 		// Group by composite key
 		if _, exists := grouped[facetKey]; !exists {
 			grouped[facetKey] = &FacetGroupInfo{
@@ -1332,15 +1319,11 @@ func groupTimeseriesByFacetMulti(results *nrdb.NRDBResultContainerMultiResultCus
 	for _, result := range resultsToProcess {
 		facetValue := ""
 		if facetArray, ok := result[utils.FacetFieldName].([]interface{}); ok && len(facetArray) > 0 {
-			// Clean up the format for array facets, extracting just the first value
 			facetValue = fmt.Sprintf("%v", facetArray[0])
-			log.DefaultLogger.Debug("Found facet array, extracted value", "value", facetValue)
 		} else if result[utils.FacetFieldName] != nil {
 			facetValue = fmt.Sprintf("%v", result[utils.FacetFieldName])
-			log.DefaultLogger.Debug("Found direct facet value", "value", facetValue)
 		}
 		if facetValue != "" {
-			log.DefaultLogger.Debug("Using facet value for grouping", "facetValue", facetValue)
 			grouped[facetValue] = append(grouped[facetValue], result)
 		}
 	}
@@ -1367,22 +1350,9 @@ func FormatFacetedTimeseriesResults(results *nrdb.NRDBResultContainerMultiResult
 	if len(results.Results) > 0 {
 		actualResults = results.Results
 		log.DefaultLogger.Debug("Using Results", "entryCount", len(actualResults))
-		// Debug facet values
-		for i, result := range actualResults {
-			if facetVal, ok := result["facet"]; ok {
-				log.DefaultLogger.Debug("Results facet", "index", i, "facet", facetVal)
-			}
-		}
 	} else {
-		// Fallback to OtherResult if Results is empty
 		actualResults = results.OtherResult
 		log.DefaultLogger.Debug("Using OtherResult", "entryCount", len(actualResults))
-		// Debug facet values
-		for i, result := range actualResults {
-			if facetVal, ok := result["facet"]; ok {
-				log.DefaultLogger.Debug("OtherResult facet", "index", i, "facet", facetVal)
-			}
-		}
 	}
 
 	standardResults := &nrdb.NRDBResultContainer{

--- a/pkg/handler/query_handler.go
+++ b/pkg/handler/query_handler.go
@@ -127,19 +127,10 @@ func injectTimeRange(nrqlQuery string, timeRange backend.TimeRange) string {
 	if fromMs > 0 && toMs > 0 {
 		injected := fmt.Sprintf("%s SINCE %d UNTIL %d", nrqlQuery, fromMs, toMs)
 		log.DefaultLogger.Debug("Injected Grafana time range into NRQL",
-			"from", timeRange.From, "to", timeRange.To, "query", injected)
+			"from", timeRange.From, "to", timeRange.To)
 		return injected
 	}
 	return nrqlQuery
-}
-
-// checkFacetAndTimeseries logs if both FACET and TIMESERIES are present in the query
-func checkFacetAndTimeseries(query string) {
-	hasFacet := strings.Contains(strings.ToUpper(query), "FACET")
-	hasTimeseries := strings.Contains(strings.ToUpper(query), "TIMESERIES")
-	if hasFacet && hasTimeseries {
-		log.DefaultLogger.Info("Query contains both FACET and TIMESERIES", "query", query)
-	}
 }
 
 // HandleQuery processes a single Grafana data query using our interface-based approach.

--- a/pkg/handler/query_handler_test.go
+++ b/pkg/handler/query_handler_test.go
@@ -346,28 +346,6 @@ func TestNRQLExecutionError_QueryHandler(t *testing.T) {
 	})
 }
 
-func TestCheckFacetAndTimeseries_QueryHandler(t *testing.T) {
-	// Since checkFacetAndTimeseries only logs and doesn't return anything,
-	// we're just calling it to increase coverage
-	t.Run("query with FACET and TIMESERIES", func(t *testing.T) {
-		query := "SELECT count(*) FROM Transaction FACET appName TIMESERIES"
-		checkFacetAndTimeseries(query)
-		// No assertions since we're just executing for coverage
-	})
-
-	t.Run("query with FACET only", func(t *testing.T) {
-		query := "SELECT count(*) FROM Transaction FACET appName"
-		checkFacetAndTimeseries(query)
-		// No assertions since we're just executing for coverage
-	})
-
-	t.Run("query with neither FACET nor TIMESERIES", func(t *testing.T) {
-		query := "SELECT count(*) FROM Transaction"
-		checkFacetAndTimeseries(query)
-		// No assertions since we're just executing for coverage
-	})
-}
-
 func TestExecuteNRQLQueryEdgeCases_QueryHandler(t *testing.T) {
 	t.Run("nil executor", func(t *testing.T) {
 		result, err := ExecuteNRQLQuery(context.Background(), nil, 123456, "SELECT count(*) FROM Transaction")

--- a/pkg/health/checker.go
+++ b/pkg/health/checker.go
@@ -52,6 +52,9 @@ func PerformHealthCheck1(ctx context.Context, dsSettings backend.DataSourceInsta
 	clientConfig := client.DefaultConfig()
 	clientConfig.APIKey = config.Secrets.ApiKey
 	clientConfig.DatasourceUID = dsSettings.UID // Set the datasource UID for unique service name
+	if config.Region != "" {
+		clientConfig.Region = config.Region
+	}
 	log.DefaultLogger.Debug("health.ExecuteHealthCheck: Creating client with UID", "uid", dsSettings.UID)
 	nrClient, err := client.NewClient(clientConfig)
 	if err != nil {

--- a/pkg/health/checker_test.go
+++ b/pkg/health/checker_test.go
@@ -350,6 +350,42 @@ func TestPerformHealthCheck1_NewClientError(t *testing.T) {
 	assert.Contains(t, result.Message, "simulated client creation error")
 }
 
+// TestPerformHealthCheck1_EURegionPassedToClient verifies that an EU region in JSONData
+// is deserialized and forwarded to checkHealthFunction via PluginSettings.
+func TestPerformHealthCheck1_EURegionPassedToClient(t *testing.T) {
+	originalCheckHealthFunc := checkHealthFunction
+	defer func() { checkHealthFunction = originalCheckHealthFunc }()
+
+	originalNewFunc := client.NewrelicNewFunc
+	defer func() { client.NewrelicNewFunc = originalNewFunc }()
+
+	client.NewrelicNewFunc = func(opts ...newrelic.ConfigOption) (*newrelic.NewRelic, error) {
+		return &newrelic.NewRelic{}, nil
+	}
+
+	var capturedRegion string
+	checkHealthFunction = func(ctx context.Context, settings *models.PluginSettings, executor nrdbiface.NRDBQueryExecutor) (*backend.CheckHealthResult, error) {
+		capturedRegion = settings.Region
+		return &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "ok"}, nil
+	}
+
+	settings := backend.DataSourceInstanceSettings{
+		ID:   1,
+		Name: "test-eu-datasource",
+		DecryptedSecureJSONData: map[string]string{
+			"apiKey":    "test-api-key",
+			"accountID": "123456",
+		},
+		JSONData: []byte(`{"region": "EU"}`),
+	}
+
+	result, err := PerformHealthCheck1(context.Background(), settings)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, backend.HealthStatusOk, result.Status)
+	assert.Equal(t, "EU", capturedRegion, "expected EU region to be deserialized from JSONData")
+}
+
 // TestPerformHealthCheck1_WithUID tests health check with datasource UID
 func TestPerformHealthCheck1_WithUID(t *testing.T) {
 	// Save original client creation function

--- a/pkg/models/query_test.go
+++ b/pkg/models/query_test.go
@@ -42,6 +42,66 @@ func TestLoadPluginSettings_Success(t *testing.T) {
 	}
 }
 
+func TestLoadPluginSettings_EURegion(t *testing.T) {
+	jsonData := `{"path": "/some/path", "region": "EU"}`
+	secureData := map[string]string{
+		"apiKey":    "test_api_key",
+		"accountID": "12345",
+	}
+
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(jsonData),
+		DecryptedSecureJSONData: secureData,
+	}
+
+	pluginSettings, err := LoadPluginSettings(settings)
+	if err != nil {
+		t.Fatalf("LoadPluginSettings failed with error: %v", err)
+	}
+
+	assert.Equal(t, "EU", pluginSettings.Region)
+}
+
+func TestLoadPluginSettings_USRegion(t *testing.T) {
+	jsonData := `{"path": "/some/path", "region": "US"}`
+	secureData := map[string]string{
+		"apiKey":    "test_api_key",
+		"accountID": "12345",
+	}
+
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(jsonData),
+		DecryptedSecureJSONData: secureData,
+	}
+
+	pluginSettings, err := LoadPluginSettings(settings)
+	if err != nil {
+		t.Fatalf("LoadPluginSettings failed with error: %v", err)
+	}
+
+	assert.Equal(t, "US", pluginSettings.Region)
+}
+
+func TestLoadPluginSettings_NoRegionDefaultsEmpty(t *testing.T) {
+	jsonData := `{"path": "/some/path"}`
+	secureData := map[string]string{
+		"apiKey":    "test_api_key",
+		"accountID": "12345",
+	}
+
+	settings := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(jsonData),
+		DecryptedSecureJSONData: secureData,
+	}
+
+	pluginSettings, err := LoadPluginSettings(settings)
+	if err != nil {
+		t.Fatalf("LoadPluginSettings failed with error: %v", err)
+	}
+
+	assert.Equal(t, "", pluginSettings.Region)
+}
+
 func TestLoadPluginSettings_InvalidJSON(t *testing.T) {
 	jsonData := `invalid json`
 	secureData := map[string]string{

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -36,6 +36,7 @@ func (e *PluginSettingsError) Unwrap() error {
 // PluginSettings holds the configuration settings for the New Relic data source.
 type PluginSettings struct {
 	Path    string                `json:"path"`
+	Region  string                `json:"region"`
 	Secrets *SecretPluginSettings `json:"-"`
 }
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -83,6 +83,9 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 	clientConfig := client.DefaultConfig()
 	clientConfig.APIKey = config.Secrets.ApiKey
 	clientConfig.DatasourceUID = datasourceUID // Set the datasource UID for unique service name
+	if config.Region != "" {
+		clientConfig.Region = config.Region
+	}
 
 	// Create New Relic client using the new method
 	nrClient, err := client.NewClient(clientConfig)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -12,8 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	nrconfig "github.com/newrelic/newrelic-client-go/v2/pkg/config"
+
+	"newrelic-grafana-plugin/pkg/client"
 	"newrelic-grafana-plugin/pkg/health"
 	"newrelic-grafana-plugin/pkg/models"
+
+	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 )
 
 // TestNewDatasource ensures that a new Datasource instance can be created.
@@ -771,4 +776,42 @@ func TestDatasource_QueryData_WithUID(t *testing.T) {
 
 	// Key verification: the UID was present in the request
 	assert.Equal(t, testUID, req.PluginContext.DataSourceInstanceSettings.UID)
+}
+
+// TestQueryData_EURegionPassedToClient verifies that an EU region in JSONData
+// is deserialized and forwarded to the New Relic client in the query path.
+func TestQueryData_EURegionPassedToClient(t *testing.T) {
+	originalLoadPluginSettings := models.LoadPluginSettings
+	defer func() { models.LoadPluginSettings = originalLoadPluginSettings }()
+
+	originalNewFunc := client.NewrelicNewFunc
+	defer func() { client.NewrelicNewFunc = originalNewFunc }()
+
+	var capturedRegion string
+	client.NewrelicNewFunc = func(opts ...newrelic.ConfigOption) (*newrelic.NewRelic, error) {
+		cfg := nrconfig.New()
+		for _, opt := range opts {
+			_ = opt(&cfg)
+		}
+		capturedRegion = cfg.Region().String()
+		return nil, fmt.Errorf("intercepted for region capture")
+	}
+
+	ds := &Datasource{}
+	_, _ = ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{"region": "EU"}`),
+				DecryptedSecureJSONData: map[string]string{
+					"apiKey":    "test-api-key",
+					"accountID": "123456",
+				},
+			},
+		},
+		Queries: []backend.DataQuery{
+			{RefID: "A", JSON: []byte(`{"queryText":"SELECT count(*) FROM Transaction","accountID":123456}`)},
+		},
+	})
+
+	assert.Equal(t, "EU", capturedRegion, "expected EU region to be forwarded to New Relic client in query path")
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -33,17 +33,19 @@ function sanitizeLogMessage(message: string): string {
  * @param obj - The object to sanitize
  * @returns Sanitized object
  */
-function sanitizeObject(obj: any): any {
-  if (!obj || typeof obj !== 'object') {
+function sanitizeObject(obj: any, depth = 0): any {
+  if (!obj || typeof obj !== 'object' || depth > 5) {
     return obj;
   }
 
   const sensitiveFields = ['apiKey', 'api_key', 'password', 'token', 'secret'];
-  const sanitized = { ...obj };
+  const sanitized = Array.isArray(obj) ? [...obj] : { ...obj };
 
-  for (const field of sensitiveFields) {
-    if (field in sanitized) {
-      sanitized[field] = '[REDACTED]';
+  for (const key of Object.keys(sanitized)) {
+    if (sensitiveFields.includes(key.toLowerCase())) {
+      sanitized[key] = '[REDACTED]';
+    } else if (sanitized[key] && typeof sanitized[key] === 'object') {
+      sanitized[key] = sanitizeObject(sanitized[key], depth + 1);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes authentication failures for EU region accounts(https://github.com/newrelic/newrelic-grafana-plugin/issues/25). 

Accounts in the Europe region received a `403 not authorized for account region` error when connecting via the plugin because the New Relic client always targeted the US endpoint regardless of the region selected in the datasource configuration.

**Changes:**
- Add `Region` field to `PluginSettings` to deserialize the region value from Grafana's `jsonData`
- Propagate `config.Region` to the New Relic client config in the query execution path (`datasource.go`) and health check path (`checker.go`)
- EU accounts now correctly target `api.eu.newrelic.com/graphql` instead of `api.newrelic.com/graphql`
- Bump plugin version to `0.2.1`